### PR TITLE
fix(ui): Attributes section of credentials has extra padding at bottom

### DIFF
--- a/src/ui/components/CardDetails/CardDetailsBlock/CardDetailsBlock.scss
+++ b/src/ui/components/CardDetails/CardDetailsBlock/CardDetailsBlock.scss
@@ -89,7 +89,7 @@
 
   &.has-content {
     .card-header {
-      margin-bottom: 1.25rem;
+      padding-bottom: 0.75rem;
     }
   }
 
@@ -117,7 +117,7 @@
   @media screen and (min-width: 250px) and (max-width: 370px) {
     &.has-content {
       .card-header {
-        margin-bottom: 0.8rem;
+        padding-bottom: 0.6rem;
       }
     }
 

--- a/src/ui/components/CardDetails/CardDetailsExpandAttributes/CardDetailsAttributes.scss
+++ b/src/ui/components/CardDetails/CardDetailsExpandAttributes/CardDetailsAttributes.scss
@@ -1,12 +1,15 @@
 @mixin expand-group {
-  .container-nested-list-item {
-    margin-top: 0.625rem;
-  }
-
   .nested-list-item {
+    padding: 0.5rem 0;
+
+    &:last-of-type {
+      padding-bottom: 0;
+    }
+
     ion-item {
       display: flex;
       align-items: center;
+      height: 1.5rem;
 
       &::part(native) {
         padding: 0.75rem 0;
@@ -15,6 +18,16 @@
 
     &:not(.container-nested-list-item) {
       padding-left: 1.5rem;
+    }
+  }
+
+  @media screen and (min-width: 250px) and (max-width: 370px) {
+    .nested-list-item {
+      padding: 0.4rem 0;
+
+      ion-item {
+        height: 1.2rem;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Removing margins and adding padding to match design.

**NOTE:** 
I couldn't test on iPhone 8 but I think that should be ok.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-2028**](https://cardanofoundation.atlassian.net/issues/DTIS-2028)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS

![31032025170608](https://github.com/user-attachments/assets/f8065fec-ed6e-4fdb-8cb6-7712820b6ba5)

#### Android

![31032025170547](https://github.com/user-attachments/assets/89e43e6c-21b3-41d8-9e4f-6bfe647c9858)
