### PR TITLE
[cred-ui] Fix regex to allow pasting and scanning group ID

### DIFF
--- a/services/credential-server-ui/package-lock.json
+++ b/services/credential-server-ui/package-lock.json
@@ -7991,9 +7991,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.2.tgz",
-      "integrity": "sha512-yW7PeMM+LkDzc7CgJuRLMW2Jz0FxMOsVJ8Lv3gpgW9WLcb9cTW+121UEr1hvmfR7w3SegR5ItvYyzVz1vxNJgQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.2.4.tgz",
+      "integrity": "sha512-veHMSew8CcRzhL5o8ONjy8gkfmFJAd5Ac16oxBUjlwgX3Gq2Wqr+qNC3TjPIpy7TPV/KporLga5GT9HqdrCizw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/services/credential-server-ui/src/components/IssueCredentialModal/Review.tsx
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/Review.tsx
@@ -56,7 +56,10 @@ const Review = ({
         </Typography>
       </Box>
       {credAttributes.map((credAttribute) => (
-        <Box sx={{ textAlign: "left" }}>
+        <Box
+          key={credAttribute.key}
+          sx={{ textAlign: "left" }}
+        >
           <Typography variant="subtitle1">
             {i18n.t(
               `pages.credentialDetails.issueCredential.inputAttribute.label.${credAttribute.label.toLowerCase()}`

--- a/services/credential-server-ui/src/components/RequestPresentationModal/Review.tsx
+++ b/services/credential-server-ui/src/components/RequestPresentationModal/Review.tsx
@@ -56,7 +56,10 @@ const Review = ({
         </Typography>
       </Box>
       {credAttributes.map((credAttribute) => (
-        <Box sx={{ textAlign: "left" }}>
+        <Box
+          key={credAttribute.key}
+          sx={{ textAlign: "left" }}
+        >
           <Typography variant="subtitle1">
             {i18n.t(
               `pages.credentialDetails.issueCredential.inputAttribute.label.${credAttribute.label.toLowerCase()}`

--- a/services/credential-server-ui/src/utils/urlChecker.ts
+++ b/services/credential-server-ui/src/utils/urlChecker.ts
@@ -14,9 +14,8 @@ const isValidHttpUrl = (urlString: string) => {
 };
 
 const isValidConnectionUrl = (url: string) => {
-  // Pattern: http://domain/oobi/:connectionId/agent/:agentId?param
   const pattern =
-    /https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+([\w])?(\.|(:\d*))?([^\s]{0,})\/oobi\/[\w-]*\/agent\/([^\s]{1,})/;
+    /https?:\/\/[a-zA-Z0-9-]+(:\d+)?\/oobi\/[\w-]+(\/agent\/[\w-]+)?(\?name=[^&]*)?$/;
 
   return pattern.test(url);
 };

--- a/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
+++ b/src/ui/pages/Menu/components/ConnectWallet/ConnectWallet.test.tsx
@@ -375,13 +375,14 @@ describe("Wallet connect: empty history", () => {
       dispatch: dispatchMock,
     };
 
-    const { getByText, queryByText, getByTestId, unmount } = render(
-      <MemoryRouter>
-        <Provider store={storeMocked}>
-          <ConnectWallet />
-        </Provider>
-      </MemoryRouter>
-    );
+    const { getByText, getAllByText, queryByText, getAllByTestId, unmount } =
+      render(
+        <MemoryRouter>
+          <Provider store={storeMocked}>
+            <ConnectWallet />
+          </Provider>
+        </MemoryRouter>
+      );
 
     await waitFor(() => {
       expect(
@@ -397,15 +398,15 @@ describe("Wallet connect: empty history", () => {
 
     await waitFor(() => {
       expect(
-        getByText(
+        getAllByText(
           EN_TRANSLATIONS.tabs.menu.tab.items.connectwallet.connectionhistory
             .missingidentifieralert.message
-        )
+        )[0]
       ).toBeVisible();
     });
 
     act(() => {
-      fireEvent.click(getByTestId("alert-create-keri-cancel-button"));
+      fireEvent.click(getAllByTestId("alert-create-keri-cancel-button")[0]);
     });
 
     await waitFor(() => {
@@ -720,7 +721,7 @@ describe("Wallet connect", () => {
       dispatch: dispatchMock,
     };
 
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getAllByTestId, getAllByText } = render(
       <MemoryRouter>
         <Provider store={storeMocked}>
           <ConnectWallet />
@@ -738,14 +739,14 @@ describe("Wallet connect", () => {
 
     await waitFor(() => {
       expect(
-        getByText(
+        getAllByText(
           EN_TRANSLATIONS.tabs.menu.tab.items.connectwallet.connectionhistory
             .missingidentifieralert.message
-        )
+        )[0]
       ).toBeVisible();
     });
 
-    fireEvent.click(getByTestId("alert-create-keri-confirm-button"));
+    fireEvent.click(getAllByTestId("alert-create-keri-confirm-button")[0]);
 
     await waitFor(() => {
       expect(getByTestId("create-identifier-modal")).toBeVisible();


### PR DESCRIPTION
## Description

In an attempt to improve the regex for pasting or scanning an OOBI I mistakenly only allowed the pattern for a single connection, thinking that the pattern would be similar for multi sig.

Changing this to allow both formats and only testing on browser as the result would be the same.

Also fixing ome flakey unit tests and a security audit warning for the cred issuance tool.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-2094**](https://cardanofoundation.atlassian.net/issues/DTIS-2094)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---

https://github.com/user-attachments/assets/d4687f5d-0e29-43a5-8aee-3c3df2b22b23

