### PR TITLE
fix(ui): After onboarding, the CTA is active when you set the name as empty space

### DIFF
--- a/src/ui/components/InputRequest/InputRequest.test.tsx
+++ b/src/ui/components/InputRequest/InputRequest.test.tsx
@@ -126,6 +126,22 @@ describe("SetUserName component", () => {
     ).toBeVisible();
   });
 
+  test("Disable CTA if username is space", async () => {
+    const { getByTestId } = render(
+      <Provider store={storeMocked}>
+        <InputRequest />
+      </Provider>
+    );
+
+    act(() => {
+      ionFireEvent.ionInput(getByTestId("input-request-input"), " ");
+    });
+
+    expect(
+      getByTestId("primary-button-input-request").getAttribute("disabled")
+    ).toBe("true");
+  });
+
   test("It should call handleConfirm when the primary button is clicked", async () => {
     const { getByText, getByTestId } = render(
       <Provider store={storeMocked}>

--- a/src/ui/components/InputRequest/InputRequest.tsx
+++ b/src/ui/components/InputRequest/InputRequest.tsx
@@ -181,7 +181,7 @@ const InputRequest = () => {
         <ErrorMessage message={errorMessage} />
         <PageFooter
           pageId={componentId}
-          primaryButtonDisabled={inputValue.length === 0}
+          primaryButtonDisabled={inputValue.trim().length === 0}
           primaryButtonText={`${i18n.t("inputrequest.button.confirm")}`}
           primaryButtonAction={() => handleConfirm()}
         />


### PR DESCRIPTION
## Description

Disable CTA button when user input space on user name input.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/issues/DTIS-2023)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Browser

https://github.com/user-attachments/assets/4ef12bcc-47e1-451c-ab71-4fb69a47a063

