### PR TITLE
fix(cred-ui): Incorrect pages in tablet menu

### DIFF
--- a/services/credential-server-ui/src/components/NavBar/NavBar.tsx
+++ b/services/credential-server-ui/src/components/NavBar/NavBar.tsx
@@ -149,7 +149,7 @@ const NavBar = ({ window }: Props) => {
             >
               <DrawerContent
                 handleDrawerToggle={handleDrawerToggle}
-                menuItems={menuItems}
+                menuItems={displayMenuItems}
               />
             </Drawer>
           </Box>


### PR DESCRIPTION
## Description

In the current tablet view, all available menu items are showing up, regardless of which one is the logged in user.
As a result, clicking on some of those links may result in an error depending on your permissions level.

In this PR I am passing down the correct filtered menu items to reflect what we have in desktop view and only show the appropriate links based on the logged in user permissions.

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-2116**](https://cardanofoundation.atlassian.net/browse/DTIS-2116)

![07042025115646](https://github.com/user-attachments/assets/2bddfea6-4bf6-4481-adbe-87888d24dbc8)
![07042025115701](https://github.com/user-attachments/assets/bd57c1a4-40f2-4f01-bde6-44222d2e142c)
