### PR TITLE
build: fix android manifest for play store

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -7,7 +7,7 @@
     "active": true,
     "notes": "SSRF attacks are not relevant to our usage of Meerkat."
   },
-  "1102472": {
+  "1103618": {
     "active": true,
     "notes": "SSRF attacks on the Appium server when e2e testing do not impact the wallet."
   }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-sdk android:minSdkVersion="29" android:targetSdkVersion="34" android:maxSdkVersion="34" />
+    <uses-sdk android:minSdkVersion="31" android:targetSdkVersion="35" android:maxSdkVersion="35" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cf-identity-wallet",
-  "version": "1.0.0",
+  "version": "1.0.1-rc1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cf-identity-wallet",
-      "version": "1.0.0",
+      "version": "1.0.1-rc1",
       "dependencies": {
         "@aparajita/capacitor-biometric-auth": "^8.0.2",
         "@capacitor-community/privacy-screen": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-identity-wallet",
-  "version": "1.0.0",
+  "version": "1.0.1-rc1",
   "private": true,
   "scripts": {
     "dev": "webpack serve --config webpack.dev.cjs --host 0.0.0.0 --port 3003",


### PR DESCRIPTION
The build.gradle values are used in the build process when building the apk to determine it's SDK version and min/max. The device compatibility list in the Play console appears to be based on those values.

The manifest file is used by the Play Store to determine if an app should be downloadable by someone or not. In recent versions, it seems we might be able to remove `uses-sdk` completely and rely on the build.gradle, so it's weird that the Play Store does not already ignore the values in this file.

This PR updates `uses-sdk` instead of removing it for the sake of risk and time.

P.S - I should name the release branches `release/1.0` or `release/1.0.X` as I'd prefer to not create a separate branch for each patch. Will fix later.