### PR TITLE
Bug/symbolguide

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -857,7 +857,7 @@
         "pendingidentifiers": "Pending identifiers",
         "multisigidentifiers": "For groups"
       },
-      "detelepending": {
+      "deletepending": {
         "title": "Identifier options",
         "description": "Your identifier is pending and may still complete. If you no longer require this identifier, tap “Delete identifier” to remove it.",
         "mutilsigdescription": "This multi-sig is pending. It will complete once it meets the required member threshold. To remove it from your pending list, tap “Delete identifier”.",
@@ -1007,7 +1007,7 @@
           "placeholder": "You currently have no {{ type }} credentials."
         },
         "pendingcred": "Pending credentials",
-        "detelepending": {
+        "deletepending": {
           "title": "Credential options",
           "description": "Your credential is pending and may still complete. If you no longer require this credential, tap “Delete credential” to remove it.",
           "button": "Delete credential",
@@ -1506,7 +1506,7 @@
         "confirm": "Create identifier",
         "cancel": "Cancel"
       },
-      "detelepending": {
+      "deletepending": {
         "title": "Connection options",
         "description": "This connection is pending. You’ll be notified once they accept. If you no longer require this connection, tap “Delete connection” to remove.",
         "button": "Delete connection",

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -768,7 +768,6 @@
       "listsymbol": {
         "space": "Space",
         "exclamationmark": "Exclamation Mark",
-        "doublequote": "Double quote",
         "numbersign": "Number sign (hash)",
         "dollarsign": "Dollar sign",
         "sterlingsign": "Sterling sign (pound)",

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -767,6 +767,7 @@
       "name": "Name",
       "listsymbol": {
         "space": "Space",
+        "exclamationmark": "Exclamation Mark",
         "doublequote": "Double quote",
         "numbersign": "Number sign (hash)",
         "dollarsign": "Dollar sign",

--- a/src/ui/components/PasswordModule/components/SymbolModal/SymbolModal.type.ts
+++ b/src/ui/components/PasswordModule/components/SymbolModal/SymbolModal.type.ts
@@ -10,7 +10,7 @@ const Symbols = [
   },
   {
     key: "!",
-    labelKey: "doublequote",
+    labelKey: "exclamationmark",
   },
   {
     key: "#",

--- a/src/ui/pages/Identifiers/Identifiers.test.tsx
+++ b/src/ui/pages/Identifiers/Identifiers.test.tsx
@@ -209,7 +209,7 @@ describe("Identifiers Tab", () => {
 
     await waitFor(() => {
       expect(
-        getByText(EN_TRANSLATIONS.tabs.identifiers.detelepending.witnesserror)
+        getByText(EN_TRANSLATIONS.tabs.identifiers.deletepending.witnesserror)
       ).toBeVisible();
     });
   });
@@ -584,7 +584,7 @@ describe("Identifiers Tab", () => {
 
     await waitFor(() => {
       expect(
-        getByText(EN_TRANSLATIONS.tabs.identifiers.detelepending.witnesserror)
+        getByText(EN_TRANSLATIONS.tabs.identifiers.deletepending.witnesserror)
       ).toBeVisible();
     });
   });
@@ -760,26 +760,26 @@ describe("Identifiers Tab", () => {
 
     await waitFor(() => {
       expect(
-        getByText(EN_TRANSLATIONS.tabs.identifiers.detelepending.title)
+        getByText(EN_TRANSLATIONS.tabs.identifiers.deletepending.title)
       ).toBeVisible();
       expect(
-        getByText(EN_TRANSLATIONS.tabs.identifiers.detelepending.description)
+        getByText(EN_TRANSLATIONS.tabs.identifiers.deletepending.description)
       ).toBeVisible();
       expect(
-        getByText(EN_TRANSLATIONS.tabs.identifiers.detelepending.button)
+        getByText(EN_TRANSLATIONS.tabs.identifiers.deletepending.button)
       ).toBeVisible();
     });
 
     act(() => {
       fireEvent.click(
-        getByText(EN_TRANSLATIONS.tabs.identifiers.detelepending.button)
+        getByText(EN_TRANSLATIONS.tabs.identifiers.deletepending.button)
       );
     });
 
     await waitFor(() => {
       expect(
         getByText(
-          EN_TRANSLATIONS.tabs.identifiers.detelepending.secondchecktitle
+          EN_TRANSLATIONS.tabs.identifiers.deletepending.secondchecktitle
         )
       ).toBeVisible();
     });


### PR DESCRIPTION
## Description

Exclamation mark had the description "double quote"

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [link]

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

(I had a date formatter exception running tests locally which I think is timezone related, but not part of my changes)

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Android
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Browser
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)