### PR TITLE
fix: bottom screen and title alignment

### DIFF
--- a/src/ui/components/CreateGroupIdentifier/CreateGroupIdentifier.scss
+++ b/src/ui/components/CreateGroupIdentifier/CreateGroupIdentifier.scss
@@ -2,6 +2,10 @@ ion-modal.create-group-identifier-modal {
   .scrollable-page-layout {
     &.initiator-view {
       padding-bottom: 4rem;
+
+      &.md {
+        padding-bottom: calc(var(--ion-safe-area-bottom) + 4rem);
+      }
     }
 
     &.keyboard-is-open ion-content.scrollable-page-content {
@@ -140,8 +144,16 @@ ion-modal.create-group-identifier-modal {
       bottom: calc(-100vh + 5rem);
       padding-inline: 0.9rem;
 
+      &.md {
+        bottom: calc(-100vh + 5rem + var(--ion-safe-area-bottom));
+      }
+
       &.identifier-stage-3 {
         bottom: calc(-100vh + 9.5rem);
+
+        &.md {
+          bottom: calc(-100vh + 9.5rem + var(--ion-safe-area-bottom));
+        }
       }
     }
   }
@@ -520,8 +532,16 @@ ion-modal.create-group-identifier-modal {
     ion-toolbar.page-footer {
       bottom: calc(-100vh + 3.5rem);
 
+      &.md {
+        bottom: calc(-100vh + 3.5rem + var(--ion-safe-area-bottom));
+      }
+
       &.identifier-stage-3 {
         bottom: calc(-100vh + 6.25rem);
+
+        &.md {
+          bottom: calc(-100vh + 6.25rem + var(--ion-safe-area-bottom));
+        }
       }
     }
   }

--- a/src/ui/components/CreateIdentifier/CreateIdentifier.scss
+++ b/src/ui/components/CreateIdentifier/CreateIdentifier.scss
@@ -26,6 +26,10 @@ ion-modal.create-identifier-modal {
 
     .page-header {
       margin-top: 0.625rem;
+
+      .buttons-last-slot {
+        display: none;
+      }
     }
 
     ion-grid {

--- a/src/ui/components/layout/ResponsiveModal/ResponsiveModal.scss
+++ b/src/ui/components/layout/ResponsiveModal/ResponsiveModal.scss
@@ -2,6 +2,12 @@ ion-modal.responsive-modal {
   --height: auto;
   --background: transparent;
 
+  &.md {
+    .responsive-modal-content {
+      padding-bottom: calc(var(--ion-safe-area-bottom) + 1.25rem);
+    }
+  }
+
   .ion-page {
     border-radius: 1rem 1rem 0rem 0rem;
   }
@@ -11,6 +17,7 @@ ion-modal.responsive-modal {
     flex-direction: column;
     justify-content: end;
     padding: 1.25rem;
+    padding-bottom: calc(var(--ion-safe-area-bottom) + 1.25rem);
     border-radius: 1rem 1rem 0rem 0rem;
     background: var(--ion-color-neutral-200);
 

--- a/src/ui/components/layout/ResponsivePageLayout/ResponsivePageLayout.scss
+++ b/src/ui/components/layout/ResponsivePageLayout/ResponsivePageLayout.scss
@@ -4,6 +4,10 @@
   padding: 1.25rem;
   background: var(--ion-color-neutral-200);
 
+  &.md {
+    padding-bottom: calc(var(--ion-safe-area-bottom) + 1.25rem);
+  }
+
   .responsive-page-content {
     display: flex;
     flex-direction: column;

--- a/src/ui/components/layout/ResponsivePageLayout/ResponsivePageLayout.tsx
+++ b/src/ui/components/layout/ResponsivePageLayout/ResponsivePageLayout.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from "react";
-import { IonPage, useIonViewDidEnter, useIonViewDidLeave } from "@ionic/react";
+import {
+  IonPage,
+  isPlatform,
+  useIonViewDidEnter,
+  useIonViewDidLeave,
+} from "@ionic/react";
 import { ResponsivePageLayoutProps } from "./ResponsivePageLayout.types";
 import "./ResponsivePageLayout.scss";
+import { combineClassNames } from "../../../utils/style";
 
 const ResponsivePageLayout = ({
   header,
@@ -23,14 +29,19 @@ const ResponsivePageLayout = ({
     activeStatus && setIsActive(activeStatus);
   }, [activeStatus]);
 
+  const className = combineClassNames(
+    `responsive-page-layout ${pageId}`,
+    customClass,
+    {
+      "ion-hide": !isActive,
+      md: isPlatform("android"),
+    }
+  );
+
   return (
     <IonPage
       data-testid={`${pageId}-page`}
-      className={
-        `responsive-page-layout ${pageId}` +
-        (!isActive ? " " + "ion-hide" : "") +
-        (customClass ? ` ${customClass}` : "")
-      }
+      className={className}
     >
       {header}
       <div className="responsive-page-content">{children}</div>

--- a/src/ui/components/layout/ScrollablePageLayout/ScrollablePageLayout.scss
+++ b/src/ui/components/layout/ScrollablePageLayout/ScrollablePageLayout.scss
@@ -4,6 +4,10 @@
   padding-inline: 1.25rem;
   background: var(--ion-color-neutral-200);
 
+  &.md {
+    padding-bottom: var(--ion-safe-area-bottom);
+  }
+
   .scrollable-page-content {
     display: flex;
     flex-direction: column;

--- a/src/ui/components/layout/ScrollablePageLayout/ScrollablePageLayout.tsx
+++ b/src/ui/components/layout/ScrollablePageLayout/ScrollablePageLayout.tsx
@@ -2,11 +2,13 @@ import { useEffect, useState } from "react";
 import {
   IonContent,
   IonPage,
+  isPlatform,
   useIonViewDidEnter,
   useIonViewDidLeave,
 } from "@ionic/react";
 import { ScrollablePageLayoutProps } from "./ScrollablePageLayout.types";
 import "./ScrollablePageLayout.scss";
+import { combineClassNames } from "../../../utils/style";
 
 const ScrollablePageLayout = ({
   header,
@@ -29,14 +31,19 @@ const ScrollablePageLayout = ({
     activeStatus && setIsActive(activeStatus);
   }, [activeStatus]);
 
+  const className = combineClassNames(
+    `scrollable-page-layout ${pageId}`,
+    customClass,
+    {
+      "ion-hide": !isActive,
+      md: isPlatform("android"),
+    }
+  );
+
   return (
     <IonPage
       data-testid={`${pageId}-page`}
-      className={
-        `scrollable-page-layout ${pageId}` +
-        (!isActive ? " " + "ion-hide" : "") +
-        (customClass ? ` ${customClass}` : "")
-      }
+      className={className}
     >
       {header}
       <IonContent className="scrollable-page-content">{children}</IonContent>


### PR DESCRIPTION
## Description

- Last updates to edge to edge support that will fix bottom screen being cut off (all Androids)

- Setup identifier title off center (all Androids)

- Copy connection URL button looks weird (small Androids only)

**NOTES:**

Tested on all devices, including iOS large and small, but only captured screenshots and videos on Android.

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**DTIS-2153**](https://cardanofoundation.atlassian.net/issues/DTIS-2153)

![15042025095113](https://github.com/user-attachments/assets/66029b7e-481c-424d-a57e-89bc4a8f560b)
![15042025095143](https://github.com/user-attachments/assets/3178d0f0-7865-44a3-a7cf-215e19011724)
![15042025095204](https://github.com/user-attachments/assets/ddeef062-7c37-4d4e-a204-f6b43f14dc21)

https://github.com/user-attachments/assets/049e3e32-ee6b-4537-a4bc-fc50611b9af7

