### PR TITLE
feat(core): forward oobi introductions to new contacts (optional)

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -15,7 +15,7 @@ ARG --global PUSH=false
 ARG --global KERIA_DOCKER_IMAGE_REPO=weboftrust/keria
 ARG --global KERIA_DOCKER_IMAGE_TAG=0.2.0-rc1
 ARG --global KERIA_GIT_REPO_URL="https://github.com/cardano-foundation/keria.git"
-ARG --global KERIA_GIT_REF="a7f39c8168d69e8aec407431e5d465debdf0a198"
+ARG --global KERIA_GIT_REF="f2ecb04f1644a5b2a8e254ea00909c2225ec3d80"
 
 ARG --global KERI_DOCKER_IMAGE_REPO=weboftrust/keri
 ARG --global KERI_DOCKER_IMAGE_TAG=1.1.26

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,9 +3,10 @@ services:
   keria:
     container_name: idw-keria
     restart: unless-stopped
-    image: cardanofoundation/cf-idw-keria:1.0.0-PR1084-caf138a-GHRUN14176398683
+    image: cardanofoundation/cf-idw-keria:1.0.0-PR1130-a3e957d-GHRUN14507582084
     environment:
       - KERI_AGENT_CORS=true
+      - ALLOW_INTRODUCTIONS=true
     volumes:
       - keria-data:/usr/local/var/keri
       - ./keria-config/config.json:/keria/scripts/keri/cf/backer-oobis.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "react-qrcode-logo": "^3.0.0",
         "react-redux": "^8.0.5",
         "react-router-dom": "^5.3.4",
-        "signify-ts": "github:WebOfTrust/signify-ts#bb3aba4de6c48a7f3574cfe283747ee6adb96f0c",
+        "signify-ts": "github:WebOfTrust/signify-ts#23b70c9dc0b3e36285ced0ca6c64568ff93fde1f",
         "swiper": "^11.1.14",
         "web-vitals": "^2.1.4"
       },
@@ -43520,8 +43520,8 @@
     },
     "node_modules/signify-ts": {
       "version": "0.3.0-rc1",
-      "resolved": "git+ssh://git@github.com/WebOfTrust/signify-ts.git#bb3aba4de6c48a7f3574cfe283747ee6adb96f0c",
-      "integrity": "sha512-GrdN1l1ZSkg6kxSwgrDiFzp3i5kTPSBywNJprB6ZksprplABW45sQbZdt8DxX5TDiJIKyNzaJLACnd0eTrBIvA==",
+      "resolved": "git+ssh://git@github.com/WebOfTrust/signify-ts.git#23b70c9dc0b3e36285ced0ca6c64568ff93fde1f",
+      "integrity": "sha512-/i9n4dKLZYF0j/wNKC151tV65zL0hPVrupTni7toYYVlZ6D90P94KHnACkwmcsNEu2SRWpzBbriff1AJ5tfIiw==",
       "license": "Apache-2.0",
       "workspaces": [
         "examples/*"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-qrcode-logo": "^3.0.0",
     "react-redux": "^8.0.5",
     "react-router-dom": "^5.3.4",
-    "signify-ts": "github:WebOfTrust/signify-ts#bb3aba4de6c48a7f3574cfe283747ee6adb96f0c",
+    "signify-ts": "github:WebOfTrust/signify-ts#23b70c9dc0b3e36285ced0ca6c64568ff93fde1f",
     "swiper": "^11.1.14",
     "web-vitals": "^2.1.4"
   },

--- a/src/core/__fixtures__/agent/identifierFixtures.ts
+++ b/src/core/__fixtures__/agent/identifierFixtures.ts
@@ -1,0 +1,17 @@
+import {
+  IdentifierMetadataRecord,
+  IdentifierMetadataRecordProps,
+} from "../../agent/records";
+
+const now = new Date();
+
+const individualRecordProps: IdentifierMetadataRecordProps = {
+  id: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_p9",
+  displayName: "Identifier 2",
+  createdAt: now,
+  theme: 0,
+};
+
+const individualRecord = new IdentifierMetadataRecord(individualRecordProps);
+
+export { individualRecord };

--- a/src/core/agent/agent.ts
+++ b/src/core/agent/agent.ts
@@ -143,7 +143,8 @@ class Agent {
         this.connectionStorage,
         this.credentialStorage,
         this.operationPendingStorage,
-        this.identifierStorage
+        this.identifierStorage,
+        this.basicStorage
       );
     }
     return this.connectionService;

--- a/src/core/agent/records/connectionRecord.ts
+++ b/src/core/agent/records/connectionRecord.ts
@@ -11,6 +11,7 @@ interface ConnectionRecordStorageProps {
   groupId?: string;
   creationStatus?: CreationStatus;
   pendingDeletion?: boolean;
+  sharedIdentifier?: string;
 }
 
 class ConnectionRecord extends BaseRecord {
@@ -19,6 +20,8 @@ class ConnectionRecord extends BaseRecord {
   groupId?: string;
   creationStatus!: CreationStatus;
   pendingDeletion!: boolean;
+  sharedIdentifier?: string;
+
   static readonly type = "ConnectionRecord";
   readonly type = ConnectionRecord.type;
 
@@ -32,6 +35,7 @@ class ConnectionRecord extends BaseRecord {
       this.groupId = props.groupId;
       this.creationStatus = props.creationStatus ?? CreationStatus.PENDING;
       this.pendingDeletion = props.pendingDeletion ?? false;
+      this.sharedIdentifier = props.sharedIdentifier;
       this._tags = props.tags ?? {};
     }
   }

--- a/src/core/agent/services/connectionService.test.ts
+++ b/src/core/agent/services/connectionService.test.ts
@@ -1,4 +1,9 @@
-import { Salter } from "signify-ts";
+/**
+ * @jest-environment node
+ */
+// @TODO - foconnor: Core tests should likely all be on node, so we can stop mocking Signify-TS/libsodium.
+
+import { ready, Salter } from "signify-ts";
 import { ConnectionStatus, CreationStatus, OobiType } from "../agent.types";
 import { ConnectionService } from "./connectionService";
 import { CoreEventEmitter } from "../event";
@@ -10,6 +15,8 @@ import {
   ConnectionHistoryType,
   KeriaContactKeyPrefix,
 } from "./connectionService.types";
+import { memberMetadataRecord } from "../../__fixtures__/agent/multiSigFixtures";
+import { individualRecord } from "../../__fixtures__/agent/identifierFixtures";
 
 const contactListMock = jest.fn();
 let deleteContactMock = jest.fn();
@@ -18,6 +25,7 @@ const getOobiMock = jest.fn();
 const getIdentifier = jest.fn();
 const saveOperationPendingMock = jest.fn();
 let contactGetMock = jest.fn();
+const submitRpyMock = jest.fn();
 
 const failUuid = "fail-uuid";
 const signifyClient = jest.mocked({
@@ -102,6 +110,9 @@ const signifyClient = jest.mocked({
     query: jest.fn(),
     get: jest.fn(),
   }),
+  replies: () => ({
+    submitRpy: submitRpyMock,
+  }),
 });
 
 const eventEmitter = new CoreEventEmitter();
@@ -140,8 +151,13 @@ const credentialStorage = jest.mocked({
   getCredentialMetadatasById: jest.fn(),
 });
 
-const identifiers = jest.mocked({
+const identifierStorage = jest.mocked({
+  getIdentifierMetadata: jest.fn(),
   getIdentifierMetadataByGroupId: jest.fn(),
+});
+
+const basicStorage = jest.mocked({
+  findExpectedById: jest.fn(),
 });
 
 const connectionService = new ConnectionService(
@@ -149,24 +165,13 @@ const connectionService = new ConnectionService(
   connectionStorage as any,
   credentialStorage as any,
   operationPendingStorage as any,
-  identifiers as any
+  identifierStorage as any,
+  basicStorage as any
 );
-
-jest.mock("uuid", () => {
-  return {
-    v4: () => "uuid",
-  };
-});
-
-jest.mock("signify-ts", () => ({
-  Salter: jest.fn().mockImplementation(() => {
-    return { qb64: "" };
-  }),
-}));
 
 const now = new Date();
 const nowISO = now.toISOString();
-const keriContacts = [
+const contacts = [
   {
     alias: "keri",
     challenges: [],
@@ -180,25 +185,20 @@ const oobiPrefix = "http://oobi.com/oobi/";
 
 describe("Connection service of agent", () => {
   beforeAll(async () => {
+    await ready();
     await new ConfigurationService().start();
   });
+
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
-  test("Should return connection type to trigger UI to create a new identifier", async () => {
+  test("Should return group initiator type to trigger UI to create a new identifier", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
     const groupId = "123";
     const connectionId = "id";
     const alias = "alias";
     const oobi = `http://localhost/oobi/${connectionId}/agent/agentId?groupId=${groupId}&name=${alias}`;
-    updateContactMock.mockResolvedValue({
-      alias,
-      oobi,
-      id: connectionId,
-      groupCreationId: groupId,
-      createdAt: now.toISOString(),
-    });
 
     const result = await connectionService.connectByOobiUrl(oobi);
 
@@ -226,23 +226,26 @@ describe("Connection service of agent", () => {
     });
   });
 
-  test("Can create groupId connections for existing pending multi-sigs", async () => {
+  test("Can create linked group connections for existing pending groups", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
     const groupId = "123";
     const connectionId = "connectionId";
     const alias = "alias";
     const oobi = `http://localhost/oobi/${connectionId}/agent/agentId?groupId=${groupId}&name=${alias}`;
-    const now = new Date();
-    updateContactMock.mockResolvedValue({
-      alias,
-      oobi,
-      id: connectionId,
-      groupCreationId: groupId,
-      createdAtUTC: now,
-    });
+    identifierStorage.getIdentifierMetadataByGroupId.mockResolvedValue(
+      memberMetadataRecord
+    );
 
     await connectionService.connectByOobiUrl(oobi);
-    expect(connectionStorage.save).toBeCalled();
+
+    expect(connectionStorage.save).toBeCalledWith({
+      id: connectionId,
+      alias,
+      createdAt: now,
+      creationStatus: CreationStatus.COMPLETE,
+      groupId,
+      oobi,
+    });
   });
 
   test("Should throw an error if invalid OOBI URL format", async () => {
@@ -285,7 +288,15 @@ describe("Connection service of agent", () => {
 
     for (const url of validUrls) {
       await connectionService.connectByOobiUrl(url);
-      expect(connectionStorage.save).toBeCalled();
+      expect(connectionStorage.save).toBeCalledWith(
+        expect.objectContaining({
+          alias: "alias",
+          creationStatus: CreationStatus.PENDING,
+          groupId: undefined,
+          id: "1234",
+          oobi: url,
+        })
+      );
     }
 
     validUrls = [
@@ -314,10 +325,29 @@ describe("Connection service of agent", () => {
     }
   });
 
+  test("Can mark an identifier to share when creating a connection", async () => {
+    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
+    const url = "https://localhost/oobi/1234/agent?name=alias";
+    identifierStorage.getIdentifierMetadata.mockResolvedValue(individualRecord);
+
+    await connectionService.connectByOobiUrl(url, individualRecord.id);
+
+    expect(connectionStorage.save).toBeCalledWith(
+      expect.objectContaining({
+        alias: "alias",
+        creationStatus: CreationStatus.PENDING,
+        groupId: undefined,
+        id: "1234",
+        oobi: url,
+        sharedIdentifier: individualRecord.id,
+      })
+    );
+  });
+
   test("can get all connections and multi-sig related ones are filtered", async () => {
     connectionStorage.findAllByQuery = jest.fn().mockResolvedValue([
       {
-        id: keriContacts[0].id,
+        id: contacts[0].id,
         createdAt: now,
         alias: "keri",
         oobi: "oobi",
@@ -326,7 +356,7 @@ describe("Connection service of agent", () => {
         pendingDeletion: false,
       },
       {
-        id: keriContacts[0].id,
+        id: contacts[0].id,
         createdAt: now,
         alias: "keri",
         oobi: "oobi",
@@ -338,14 +368,14 @@ describe("Connection service of agent", () => {
 
     expect(await connectionService.getConnections()).toEqual([
       {
-        id: keriContacts[0].id,
+        id: contacts[0].id,
         label: "keri",
         oobi: "oobi",
         status: ConnectionStatus.CONFIRMED,
         createdAtUTC: expect.any(String),
       },
       {
-        id: keriContacts[0].id,
+        id: contacts[0].id,
         label: "keri",
         oobi: "oobi",
         status: ConnectionStatus.PENDING,
@@ -395,16 +425,18 @@ describe("Connection service of agent", () => {
       title: "title",
       message: "message",
     };
-    const id = new Salter({}).qb64;
+
     await connectionService.createConnectionNote(connectionId, note);
-    const mockCallArg = updateContactMock.mock.calls[0][1];
-    const parsedNote = JSON.parse(mockCallArg[`note:${id}`]);
+
+    const parsedNote = JSON.parse(
+      Object.values(updateContactMock.mock.calls[0][1])[0] as string
+    );
 
     expect(parsedNote).toEqual(
       expect.objectContaining({
         title: note.title,
         message: note.message,
-        id: `note:${id}`,
+        id: expect.stringMatching(/^note:[A-Za-z0-9_-]{24}$/),
         timestamp: expect.stringMatching(
           /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
         ),
@@ -442,24 +474,7 @@ describe("Connection service of agent", () => {
     });
   });
 
-  test("can receive keri oobi", async () => {
-    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
-    const groupId = "123";
-    const connectionId = "connectionId";
-    const alias = "alias";
-    const oobi = `http://localhost/oobi/${connectionId}/agent/agentId?groupId=${groupId}&name=${alias}`;
-    const now = new Date();
-    updateContactMock.mockResolvedValue({
-      alias,
-      oobi,
-      id: connectionId,
-      groupCreationId: groupId,
-      createdAtUTC: now,
-    });
-    await connectionService.connectByOobiUrl(oobi);
-  });
-
-  test("can get a KERI OOBI with an alias (URL encoded)", async () => {
+  test("can get an OOBI with an alias (URL encoded)", async () => {
     Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
     getOobiMock.mockImplementation((name: string) => {
       return {
@@ -471,8 +486,10 @@ describe("Connection service of agent", () => {
       return `${oobiPrefix}${name}`;
     });
     const id = "keriuuid";
-    const KeriOobi = await connectionService.getOobi(id, "alias with spaces");
-    expect(KeriOobi).toEqual(`${oobiPrefix}${id}?name=alias+with+spaces`);
+
+    const oobi = await connectionService.getOobi(id, "alias with spaces");
+
+    expect(oobi).toEqual(`${oobiPrefix}${id}?name=alias+with+spaces`);
   });
 
   test("can get KERI OOBI with alias and groupId", async () => {
@@ -490,46 +507,46 @@ describe("Connection service of agent", () => {
 
   test("can get connection short details by id", async () => {
     connectionStorage.findById = jest.fn().mockResolvedValue({
-      id: keriContacts[0].id,
+      id: contacts[0].id,
       createdAt: now,
       alias: "keri",
       getTag: jest.fn(),
       creationStatus: CreationStatus.COMPLETE,
     });
     expect(
-      await connectionService.getConnectionShortDetailById(keriContacts[0].id)
+      await connectionService.getConnectionShortDetailById(contacts[0].id)
     ).toMatchObject({
-      id: keriContacts[0].id,
+      id: contacts[0].id,
       createdAtUTC: nowISO,
       label: "keri",
       status: ConnectionStatus.CONFIRMED,
     });
-    expect(connectionStorage.findById).toBeCalledWith(keriContacts[0].id);
+    expect(connectionStorage.findById).toBeCalledWith(contacts[0].id);
   });
 
   test("can get failed connection short details by id", async () => {
     connectionStorage.findById = jest.fn().mockResolvedValue({
-      id: keriContacts[0].id,
+      id: contacts[0].id,
       createdAt: now,
       alias: "keri",
       getTag: jest.fn(),
       creationStatus: CreationStatus.FAILED,
     });
     expect(
-      await connectionService.getConnectionShortDetailById(keriContacts[0].id)
+      await connectionService.getConnectionShortDetailById(contacts[0].id)
     ).toMatchObject({
-      id: keriContacts[0].id,
+      id: contacts[0].id,
       createdAtUTC: nowISO,
       label: "keri",
       status: ConnectionStatus.FAILED,
     });
-    expect(connectionStorage.findById).toBeCalledWith(keriContacts[0].id);
+    expect(connectionStorage.findById).toBeCalledWith(contacts[0].id);
   });
 
   test("cannot get connection short details if it does not exist", async () => {
     connectionStorage.findById = jest.fn().mockResolvedValue(null);
     await expect(
-      connectionService.getConnectionShortDetailById(keriContacts[0].id)
+      connectionService.getConnectionShortDetailById(contacts[0].id)
     ).rejects.toThrowError(
       ConnectionService.CONNECTION_METADATA_RECORD_NOT_FOUND
     );
@@ -559,6 +576,7 @@ describe("Connection service of agent", () => {
         createdAt: DATE.toISOString(),
         challenges: [],
         wellKnowns: [],
+        sharedIdentifier: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_p9",
       },
       {
         id: "ECTcHGs3EhJEdVTW10vm5pkiDlOXlR8bPBj9-8LSpZ3W",
@@ -594,6 +612,7 @@ describe("Connection service of agent", () => {
       createdAt: DATE,
       oobi: "http://dev.keria.cf-keripy.metadata.dev.cf-deployments.org:3902/oobi/EBaDnyriYK_FAruigHO42avVN40fOlVSUxpxXJ1fNxFR/agent/EP48HXCPvtzGu0c90gG9fkOYiSoi6U5Am-XaqcoNHTBl",
       groupId: "group-id",
+      sharedIdentifier: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_p9",
       creationStatus: CreationStatus.COMPLETE,
     });
     expect(connectionStorage.save).toBeCalledWith({
@@ -601,6 +620,7 @@ describe("Connection service of agent", () => {
       alias: "MySecondContact",
       createdAt: DATE,
       oobi: "http://dev.keria.cf-keripy.metadata.dev.cf-deployments.org:3902/oobi/ECTcHGs3EhJEdVTW10vm5pkiDlOXlR8bPBj9-8LSpZ3W/agent/EJMV0RgikXM7jyvXB9oOyKSZzo_AsYrEgP15Ly0dwzEL",
+      sharedIdentifier: "",
       creationStatus: CreationStatus.COMPLETE,
     });
   });
@@ -753,7 +773,7 @@ describe("Connection service of agent", () => {
   test("can get all connections that have multi-sig related", async () => {
     connectionStorage.findAllByQuery = jest.fn().mockResolvedValue([
       {
-        id: keriContacts[0].id,
+        id: contacts[0].id,
         createdAt: now,
         alias: "keri",
         oobi: "oobi",
@@ -835,7 +855,7 @@ describe("Connection service of agent", () => {
   test("Can get connection pending deletion keri", async () => {
     connectionStorage.findAllByQuery = jest.fn().mockResolvedValueOnce([
       {
-        id: keriContacts[0].id,
+        id: contacts[0].id,
         createdAt: now,
         alias: "keri",
         oobi: "oobi",
@@ -846,13 +866,13 @@ describe("Connection service of agent", () => {
     ]);
     expect(
       await connectionService.getConnectionsPendingDeletion()
-    ).toMatchObject([keriContacts[0].id]);
+    ).toMatchObject([contacts[0].id]);
     expect(connectionStorage.findAllByQuery).toBeCalledTimes(1);
   });
 
   test("Should mark connection is pending when start delete connection", async () => {
     const connectionProps = {
-      id: keriContacts[0].id,
+      id: contacts[0].id,
       createdAt: now,
       alias: "keri",
       getTag: jest.fn(),
@@ -863,12 +883,12 @@ describe("Connection service of agent", () => {
       .mockResolvedValueOnce(connectionProps);
     eventEmitter.emit = jest.fn();
 
-    await connectionService.markConnectionPendingDelete(keriContacts[0].id);
+    await connectionService.markConnectionPendingDelete(contacts[0].id);
 
     expect(eventEmitter.emit).toHaveBeenCalledWith({
       type: EventTypes.ConnectionRemoved,
       payload: {
-        connectionId: keriContacts[0].id,
+        connectionId: contacts[0].id,
       },
     });
     expect(connectionStorage.update).toBeCalledWith(connectionProps);
@@ -877,7 +897,7 @@ describe("Connection service of agent", () => {
   test("Should return when result find connection by id is empty", async () => {
     connectionStorage.findById = jest.fn().mockResolvedValueOnce(undefined);
 
-    await connectionService.markConnectionPendingDelete(keriContacts[0].id);
+    await connectionService.markConnectionPendingDelete(contacts[0].id);
 
     expect(connectionStorage.update).not.toBeCalled();
   });
@@ -888,8 +908,8 @@ describe("Connection service of agent", () => {
       .fn()
       .mockRejectedValue(new Error("request - 404 - SignifyClient message"));
 
-    await connectionService.deleteConnectionById(keriContacts[0].id);
-    expect(connectionStorage.deleteById).toBeCalledWith(keriContacts[0].id);
+    await connectionService.deleteConnectionById(contacts[0].id);
+    expect(connectionStorage.deleteById).toBeCalledWith(contacts[0].id);
   });
 
   test("Throws error if keria throw error with a non-404 error", async () => {
@@ -899,7 +919,7 @@ describe("Connection service of agent", () => {
     deleteContactMock.mockRejectedValueOnce(error);
 
     await expect(
-      connectionService.deleteConnectionById(keriContacts[0].id)
+      connectionService.deleteConnectionById(contacts[0].id)
     ).rejects.toThrow("Some other error - 500");
   });
   test("can get connection by id", async () => {
@@ -944,7 +964,7 @@ describe("Connection service of agent", () => {
     );
 
     connectionStorage.findById = jest.fn().mockResolvedValue({
-      id: keriContacts[0].id,
+      id: contacts[0].id,
       createdAtUTC: now,
       alias: "keri",
       oobi: "oobi",
@@ -973,7 +993,7 @@ describe("Connection service of agent", () => {
   test("Can get pending connection", async () => {
     connectionStorage.findAllByQuery = jest.fn().mockResolvedValueOnce([
       {
-        id: keriContacts[0].id,
+        id: contacts[0].id,
         createdAt: now,
         alias: "keri",
         oobi: "oobi",
@@ -992,7 +1012,7 @@ describe("Connection service of agent", () => {
 
     expect(result).toEqual([
       expect.objectContaining({
-        id: keriContacts[0].id,
+        id: contacts[0].id,
         createdAt: now,
         alias: "keri",
         oobi: "oobi",
@@ -1202,5 +1222,67 @@ describe("Connection service of agent", () => {
         (item) => item.type === ConnectionHistoryType.IPEX_AGREE_COMPLETE
       )
     ).toBe(false);
+  });
+
+  test("Can share an identifier with a connection", async () => {
+    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
+    connectionStorage.findById.mockResolvedValue({
+      id: "test-id",
+      createdAt: new Date(nowISO),
+      alias: "alias",
+      oobi: "http://test.oobi",
+    });
+    basicStorage.findExpectedById.mockResolvedValue({
+      content: { userName: "Alice" },
+    });
+    getOobiMock.mockImplementation((name: string) => {
+      return {
+        oobis: [`${oobiPrefix}${name}`],
+        done: true,
+      };
+    });
+    signifyClient.oobis().get = jest.fn().mockImplementation((name: string) => {
+      return `${oobiPrefix}${name}`;
+    });
+
+    await connectionService.shareIdentifier("connectionId", "ourIdentifier");
+
+    expect(submitRpyMock.mock.calls[0][0]).toBe("connectionId");
+    const rpyIms: string = submitRpyMock.mock.calls[0][1];
+    expect(rpyIms.includes("/introduce"));
+    expect(rpyIms.includes("\"http://oobi.com/oobi/ourIdentifier?name=Alice\""));
+  });
+
+  test("Shared identifier OOBIs carry over the external ID hint", async () => {
+    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValueOnce(true);
+    connectionStorage.findById.mockResolvedValue({
+      id: "test-id",
+      createdAt: new Date(nowISO),
+      alias: "alias",
+      oobi: "http://test.oobi?name=Bob&externalId=test123&randomQueryParam=random",
+    });
+    basicStorage.findExpectedById.mockResolvedValue({
+      content: { userName: "Alice" },
+    });
+    getOobiMock.mockImplementation((name: string) => {
+      return {
+        oobis: [`${oobiPrefix}${name}`],
+        done: true,
+      };
+    });
+    signifyClient.oobis().get = jest.fn().mockImplementation((name: string) => {
+      return `${oobiPrefix}${name}`;
+    });
+
+    await connectionService.shareIdentifier("connectionId", "ourIdentifier");
+
+    expect(submitRpyMock.mock.calls[0][0]).toBe("connectionId");
+    const rpyIms: string = submitRpyMock.mock.calls[0][1];
+    expect(rpyIms.includes("/introduce"));
+    expect(
+      rpyIms.includes(
+        "\"http://oobi.com/oobi/ourIdentifier?name=Alice&externalId=test123\""
+      )
+    );
   });
 });

--- a/src/core/agent/services/connectionService.types.ts
+++ b/src/core/agent/services/connectionService.types.ts
@@ -22,6 +22,22 @@ enum ConnectionHistoryType {
   IPEX_AGREE_COMPLETE,
 }
 
-export { ConnectionHistoryType, KeriaContactKeyPrefix };
+enum RpyRoute {
+  INTRODUCE = "/introduce",
+}
+
+enum OobiQueryParams {
+  NAME = "name",
+  GROUP_ID = "groupId",
+  ROLE = "role",
+  EXTERNAL_ID = "externalId",
+}
+
+export {
+  ConnectionHistoryType,
+  KeriaContactKeyPrefix,
+  RpyRoute,
+  OobiQueryParams,
+};
 
 export type { ConnectionHistoryItem, ExnMessage };

--- a/src/core/agent/services/identifierService.ts
+++ b/src/core/agent/services/identifierService.ts
@@ -35,6 +35,7 @@ import {
   NotificationRemovedEvent,
 } from "../event.types";
 import { StorageMessage } from "../../storage/storage.types";
+import { OobiQueryParams } from "./connectionService.types";
 
 const UI_THEMES = [
   0, 1, 2, 3, 10, 11, 12, 13, 20, 21, 22, 23, 30, 31, 32, 33, 40, 41, 42, 43,
@@ -687,7 +688,7 @@ class IdentifierService extends AgentService {
 
     const witnesses = [];
     for (const oobi of config.iurls) {
-      const role = new URL(oobi).searchParams.get("role");
+      const role = new URL(oobi).searchParams.get(OobiQueryParams.ROLE);
       if (role === "witness") {
         witnesses.push(oobi.split("/oobi/")[1].split("/")[0]); // EID - endpoint identifier
       }

--- a/src/core/agent/services/keriaNotificationService.test.ts
+++ b/src/core/agent/services/keriaNotificationService.test.ts
@@ -40,7 +40,6 @@ import {
 } from "../../__fixtures__/agent/keriaNotificationFixtures";
 import { ConnectionHistoryType } from "./connectionService.types";
 import { StorageMessage } from "../../storage/storage.types";
-import { OperationPendingRecordType } from "../records/operationPendingRecord.type";
 import {
   getMemberIdentifierResponse,
   getMultisigIdentifierResponse,
@@ -237,7 +236,7 @@ const credentialService = jest.mocked({
   markAcdc: jest.fn(),
 });
 
-const connectionsService = jest.mocked({
+const connectionService = jest.mocked({
   resolveOobi: jest.fn(),
   getConnectionById: jest.fn().mockResolvedValue({
     serviceEndpoints: [
@@ -245,6 +244,7 @@ const connectionsService = jest.mocked({
     ],
     historyItems: [],
   }),
+  shareIdentifier: jest.fn(),
 });
 const keriaNotificationService = new KeriaNotificationService(
   agentServicesProps,
@@ -257,7 +257,7 @@ const keriaNotificationService = new KeriaNotificationService(
   multiSigs as any,
   ipexCommunications as any,
   credentialService as any,
-  connectionsService as any,
+  connectionService as any,
   Agent.agent.getKeriaOnlineStatus,
   Agent.agent.markAgentStatus,
   Agent.agent.connect
@@ -1122,7 +1122,7 @@ describe("Signify notification service of agent", () => {
     exchangesGetMock.mockResolvedValueOnce(grantExn);
     notificationStorage.findAllByQuery.mockResolvedValue([]);
 
-    connectionsService.getConnectionById.mockResolvedValue({
+    connectionService.getConnectionById.mockResolvedValue({
       id: grantExn.exn.i,
       historyItems: [
         { id: grantExn.exn.d, type: ConnectionHistoryType.CREDENTIAL_ISSUANCE },
@@ -1140,7 +1140,7 @@ describe("Signify notification service of agent", () => {
     expect(notificationStorage.findAllByQuery).toHaveBeenCalledWith({
       exnSaid: exchange.exn.e.exn.p,
     });
-    expect(connectionsService.getConnectionById).toHaveBeenCalledWith(
+    expect(connectionService.getConnectionById).toHaveBeenCalledWith(
       grantExn.exn.i,
       true
     );
@@ -1165,7 +1165,7 @@ describe("Signify notification service of agent", () => {
     exchangesGetMock.mockResolvedValueOnce(grantExn);
     notificationStorage.findAllByQuery.mockResolvedValue([]);
 
-    connectionsService.getConnectionById.mockResolvedValue({
+    connectionService.getConnectionById.mockResolvedValue({
       id: grantExn.exn.i,
       historyItems: [],
     });
@@ -1182,7 +1182,7 @@ describe("Signify notification service of agent", () => {
     expect(notificationStorage.findAllByQuery).toHaveBeenCalledWith({
       exnSaid: exchange.exn.e.exn.p,
     });
-    expect(connectionsService.getConnectionById).toHaveBeenCalledWith(
+    expect(connectionService.getConnectionById).toHaveBeenCalledWith(
       grantExn.exn.i,
       true
     );
@@ -1224,7 +1224,7 @@ describe("Signify notification service of agent", () => {
     expect(notificationStorage.findAllByQuery).toHaveBeenCalledWith({
       exnSaid: exchange.exn.e.exn.p,
     });
-    expect(connectionsService.getConnectionById).not.toHaveBeenCalled();
+    expect(connectionService.getConnectionById).not.toHaveBeenCalled();
     expect(markNotificationMock).not.toHaveBeenCalled();
     expect(notificationStorage.update).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1268,7 +1268,7 @@ describe("Signify notification service of agent", () => {
     exchangesGetMock.mockResolvedValueOnce(applyExn);
     notificationStorage.findAllByQuery.mockResolvedValue([]);
 
-    connectionsService.getConnectionById.mockResolvedValue({
+    connectionService.getConnectionById.mockResolvedValue({
       id: applyExn.exn.i,
       historyItems: [
         {
@@ -1290,7 +1290,7 @@ describe("Signify notification service of agent", () => {
     expect(notificationStorage.findAllByQuery).toHaveBeenCalledWith({
       exnSaid: applyForPresentingExnMessage.exn.d,
     });
-    expect(connectionsService.getConnectionById).toHaveBeenCalledWith(
+    expect(connectionService.getConnectionById).toHaveBeenCalledWith(
       applyExn.exn.i,
       true
     );
@@ -1315,7 +1315,7 @@ describe("Signify notification service of agent", () => {
     exchangesGetMock.mockResolvedValueOnce(applyExn);
     notificationStorage.findAllByQuery.mockResolvedValue([]);
 
-    connectionsService.getConnectionById.mockResolvedValue({
+    connectionService.getConnectionById.mockResolvedValue({
       id: applyExn.exn.i,
       historyItems: [],
     });
@@ -1333,7 +1333,7 @@ describe("Signify notification service of agent", () => {
     expect(notificationStorage.findAllByQuery).toHaveBeenCalledWith({
       exnSaid: applyForPresentingExnMessage.exn.d,
     });
-    expect(connectionsService.getConnectionById).toHaveBeenCalledWith(
+    expect(connectionService.getConnectionById).toHaveBeenCalledWith(
       applyExn.exn.i,
       true
     );
@@ -1381,7 +1381,7 @@ describe("Signify notification service of agent", () => {
     expect(notificationStorage.findAllByQuery).toHaveBeenCalledWith({
       exnSaid: applyForPresentingExnMessage.exn.d,
     });
-    expect(connectionsService.getConnectionById).not.toHaveBeenCalled();
+    expect(connectionService.getConnectionById).not.toHaveBeenCalled();
     expect(markNotificationMock).not.toHaveBeenCalled();
     expect(notificationStorage.update).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1425,7 +1425,7 @@ describe("Signify notification service of agent", () => {
     exchangesGetMock.mockResolvedValueOnce(agreeExn);
     notificationStorage.findAllByQuery.mockResolvedValue([]);
 
-    connectionsService.getConnectionById.mockResolvedValue({
+    connectionService.getConnectionById.mockResolvedValue({
       id: exchange.exn.i,
       historyItems: [
         {
@@ -1447,7 +1447,7 @@ describe("Signify notification service of agent", () => {
     expect(notificationStorage.findAllByQuery).toHaveBeenCalledWith({
       exnSaid: agreeForPresentingExnMessage.exn.d,
     });
-    expect(connectionsService.getConnectionById).toHaveBeenCalledWith(
+    expect(connectionService.getConnectionById).toHaveBeenCalledWith(
       agreeExn.exn.i,
       true
     );
@@ -1472,7 +1472,7 @@ describe("Signify notification service of agent", () => {
     exchangesGetMock.mockResolvedValueOnce(agreeExn);
     notificationStorage.findAllByQuery.mockResolvedValue([]);
 
-    connectionsService.getConnectionById.mockResolvedValue({
+    connectionService.getConnectionById.mockResolvedValue({
       id: agreeExn.exn.i,
       historyItems: [],
     });
@@ -1490,7 +1490,7 @@ describe("Signify notification service of agent", () => {
     expect(notificationStorage.findAllByQuery).toHaveBeenCalledWith({
       exnSaid: agreeForPresentingExnMessage.exn.d,
     });
-    expect(connectionsService.getConnectionById).toHaveBeenCalledWith(
+    expect(connectionService.getConnectionById).toHaveBeenCalledWith(
       agreeExn.exn.i,
       true
     );
@@ -1534,7 +1534,7 @@ describe("Signify notification service of agent", () => {
     expect(notificationStorage.findAllByQuery).toHaveBeenCalledWith({
       exnSaid: agreeForPresentingExnMessage.exn.d,
     });
-    expect(connectionsService.getConnectionById).not.toHaveBeenCalled();
+    expect(connectionService.getConnectionById).not.toHaveBeenCalled();
     expect(markNotificationMock).not.toHaveBeenCalled();
     expect(notificationStorage.update).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1565,7 +1565,7 @@ describe("Signify notification service of agent", () => {
     );
     notificationStorage.findAllByQuery = jest.fn().mockResolvedValue([]);
     credentialStorage.getCredentialMetadata.mockResolvedValue(null);
-    connectionsService.getConnectionById.mockResolvedValueOnce({
+    connectionService.getConnectionById.mockResolvedValueOnce({
       id: multisigExnAdmitForIssuance.exn.i,
       historyItems: [],
       serviceEndpoints: [
@@ -2190,7 +2190,7 @@ describe("Group IPEX presentation", () => {
       .mockResolvedValueOnce(applyForPresentingExnMessage);
     notificationStorage.findAllByQuery = jest.fn().mockResolvedValue([]);
 
-    connectionsService.getConnectionById.mockResolvedValueOnce({
+    connectionService.getConnectionById.mockResolvedValueOnce({
       id: multisigExnOfferForPresenting.exn.i,
       historyItems: [],
       serviceEndpoints: [
@@ -2267,7 +2267,7 @@ describe("Group IPEX presentation", () => {
       .mockResolvedValueOnce(agreeForPresentingExnMessage);
     notificationStorage.findAllByQuery = jest.fn().mockResolvedValue([]);
 
-    connectionsService.getConnectionById.mockResolvedValueOnce({
+    connectionService.getConnectionById.mockResolvedValueOnce({
       id: multisigExnGrant.exn.i,
       historyItems: [],
       serviceEndpoints: [
@@ -2851,6 +2851,7 @@ describe("Long running operation tracker", () => {
 
     await keriaNotificationService.processOperation(operationRecord);
 
+    expect(connectionService.shareIdentifier).not.toBeCalled();
     expect(connectionStorage.update).toBeCalledWith({
       id: connectionMock.id,
       creationStatus: CreationStatus.COMPLETE,
@@ -2862,6 +2863,7 @@ describe("Long running operation tracker", () => {
       alias: "CF Credential Issuance",
       createdAt: operationMock.response.dt,
       oobi: "http://oobi.com/",
+      sharedIdentifier: "",
     });
     expect(eventEmitter.emit).toHaveBeenNthCalledWith(1, {
       type: EventTypes.ConnectionStateChanged,
@@ -2871,6 +2873,129 @@ describe("Long running operation tracker", () => {
       },
     });
     expect(eventEmitter.emit).toHaveBeenNthCalledWith(2, {
+      type: EventTypes.OperationComplete,
+      payload: {
+        opType: operationRecord.recordType,
+        oid: "AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      },
+    });
+    expect(operationPendingStorage.deleteById).toBeCalledWith(
+      "oobi.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA"
+    );
+  });
+
+  test("Should handle long operations with type oobi and share specified identifier", async () => {
+    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
+    const operationMock = {
+      metadata: {
+        said: "said",
+        oobi: "http://keria:3902/oobi/ELDjcyhsjppizfKQ_AvYeF4RuF1u0O6ya6OYUM6zLYH-/agent/EI4-oLA5XcrZepuB5mDrl3279EjbFtiDrz4im5Q4Ht0O?name=CF%20Credential%20Issuance",
+      },
+      done: true,
+      response: {
+        i: "id",
+        dt: new Date(),
+      },
+    };
+    operationsGetMock.mockResolvedValue(operationMock);
+    const connectionMock = {
+      id: "id",
+      creationStatus: CreationStatus.PENDING,
+      createdAt: new Date(),
+      alias: "CF Credential Issuance",
+      oobi: "http://oobi.com/",
+      sharedIdentifier: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_p9",
+    };
+    connectionStorage.findById.mockResolvedValueOnce(connectionMock);
+    const operationRecord = {
+      type: "OperationPendingRecord",
+      id: "oobi.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      createdAt: new Date("2024-08-01T10:36:17.814Z"),
+      recordType: "oobi",
+      updatedAt: new Date("2024-08-01T10:36:17.814Z"),
+    } as OperationPendingRecord;
+    contactGetMock.mockResolvedValueOnce(null);
+
+    await keriaNotificationService.processOperation(operationRecord);
+
+    expect(connectionService.shareIdentifier).toBeCalledWith(
+      connectionMock.id,
+      "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_p9"
+    );
+    expect(connectionStorage.update).toBeCalledWith({
+      id: connectionMock.id,
+      creationStatus: CreationStatus.COMPLETE,
+      createdAt: operationMock.response.dt,
+      alias: connectionMock.alias,
+      oobi: "http://oobi.com/",
+      sharedIdentifier: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_p9",
+    });
+    expect(contactsUpdateMock).toBeCalledWith(connectionMock.id, {
+      alias: "CF Credential Issuance",
+      createdAt: operationMock.response.dt,
+      oobi: "http://oobi.com/",
+      sharedIdentifier: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_p9",
+    });
+    expect(eventEmitter.emit).toHaveBeenNthCalledWith(1, {
+      type: EventTypes.ConnectionStateChanged,
+      payload: {
+        connectionId: "id",
+        status: ConnectionStatus.CONFIRMED,
+      },
+    });
+    expect(eventEmitter.emit).toHaveBeenNthCalledWith(2, {
+      type: EventTypes.OperationComplete,
+      payload: {
+        opType: operationRecord.recordType,
+        oid: "AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      },
+    });
+    expect(operationPendingStorage.deleteById).toBeCalledWith(
+      "oobi.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA"
+    );
+  });
+
+  test("Should not update connection if it already exists", async () => {
+    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
+    const operationMock = {
+      metadata: {
+        said: "said",
+        oobi: "http://keria:3902/oobi/ELDjcyhsjppizfKQ_AvYeF4RuF1u0O6ya6OYUM6zLYH-/agent/EI4-oLA5XcrZepuB5mDrl3279EjbFtiDrz4im5Q4Ht0O?name=CF%20Credential%20Issuance",
+      },
+      done: true,
+      response: {
+        i: "id",
+        dt: new Date(),
+      },
+    };
+    operationsGetMock.mockResolvedValue(operationMock);
+    operationsGetMock.mockResolvedValue(operationMock);
+    const connectionMock = {
+      id: "id",
+      creationStatus: CreationStatus.PENDING,
+      createdAt: new Date(),
+      alias: "CF Credential Issuance",
+    };
+    connectionStorage.findById.mockResolvedValueOnce(connectionMock);
+    const operationRecord = {
+      type: "OperationPendingRecord",
+      id: "oobi.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
+      createdAt: new Date("2024-08-01T10:36:17.814Z"),
+      recordType: "oobi",
+      updatedAt: new Date("2024-08-01T10:36:17.814Z"),
+    } as OperationPendingRecord;
+    contactGetMock.mockResolvedValueOnce({
+      alias: "alias",
+      oobi: "oobi",
+      id: "id",
+      createdAt: new Date(),
+    });
+
+    await keriaNotificationService.processOperation(operationRecord);
+
+    expect(connectionStorage.update).toHaveBeenCalledWith(connectionMock);
+    expect(contactsUpdateMock).toBeCalledTimes(0);
+    expect(eventEmitter.emit).toHaveBeenCalledWith({
       type: EventTypes.OperationComplete,
       payload: {
         opType: operationRecord.recordType,

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -40,11 +40,7 @@ import {
   randomSalt,
 } from "./utils";
 import { CredentialService } from "./credentialService";
-import {
-  ConnectionHistoryItem,
-  ConnectionHistoryType,
-  ExnMessage,
-} from "./connectionService.types";
+import { ConnectionHistoryType, ExnMessage } from "./connectionService.types";
 import { NotificationAttempts } from "../records/notificationRecord.types";
 import { StorageMessage } from "../../storage/storage.types";
 import { IdentifierService } from "./identifierService";
@@ -698,183 +694,183 @@ class KeriaNotificationService extends AgentService {
     exchange: ExnMessage
   ): Promise<false> {
     switch (exchange.exn.e?.exn?.r) {
-    case ExchangeRoute.IpexAdmit: {
-      const grantNotificationRecords =
+      case ExchangeRoute.IpexAdmit: {
+        const grantNotificationRecords =
           await this.notificationStorage.findAllByQuery({
             exnSaid: exchange.exn.e.exn.p,
           });
 
-      // Either relates to an processed and deleted grant notification, or is out of order
-      if (grantNotificationRecords.length === 0) {
-        const grantExn = await this.props.signifyClient
-          .exchanges()
-          .get(exchange.exn.e.exn.p);
-        const connectionInCloud =
+        // Either relates to an processed and deleted grant notification, or is out of order
+        if (grantNotificationRecords.length === 0) {
+          const grantExn = await this.props.signifyClient
+            .exchanges()
+            .get(exchange.exn.e.exn.p);
+          const connectionInCloud =
             await this.connectionService.getConnectionById(
               grantExn.exn.i,
               true
             );
-        const historyExists = connectionInCloud.historyItems.some(
-          (item) => item.id === grantExn.exn.d
-        );
-        if (historyExists) {
-          await this.markNotification(notif.i);
-          return false;
-        } else {
-          throw new Error(KeriaNotificationService.OUT_OF_ORDER_NOTIFICATION);
+          const historyExists = connectionInCloud.historyItems.some(
+            (item) => item.id === grantExn.exn.d
+          );
+          if (historyExists) {
+            await this.markNotification(notif.i);
+            return false;
+          } else {
+            throw new Error(KeriaNotificationService.OUT_OF_ORDER_NOTIFICATION);
+          }
         }
-      }
 
-      // Refresh the date and read status for UI, and link
-      const notificationRecord = grantNotificationRecords[0];
-      notificationRecord.linkedRequest = {
-        ...notificationRecord.linkedRequest,
-        current: exchange.exn.d,
-      };
-      notificationRecord.createdAt = new Date(notif.dt);
-      notificationRecord.read = false;
+        // Refresh the date and read status for UI, and link
+        const notificationRecord = grantNotificationRecords[0];
+        notificationRecord.linkedRequest = {
+          ...notificationRecord.linkedRequest,
+          current: exchange.exn.d,
+        };
+        notificationRecord.createdAt = new Date(notif.dt);
+        notificationRecord.read = false;
 
-      await this.notificationStorage.update(notificationRecord);
+        await this.notificationStorage.update(notificationRecord);
 
-      this.props.eventEmitter.emit<NotificationRemovedEvent>({
-        type: EventTypes.NotificationRemoved,
-        payload: {
-          id: notificationRecord.id,
-        },
-      });
-      this.props.eventEmitter.emit<NotificationAddedEvent>({
-        type: EventTypes.NotificationAdded,
-        payload: {
-          note: {
+        this.props.eventEmitter.emit<NotificationRemovedEvent>({
+          type: EventTypes.NotificationRemoved,
+          payload: {
             id: notificationRecord.id,
-            createdAt: notificationRecord.createdAt.toISOString(),
-            a: notificationRecord.a,
-            connectionId: notificationRecord.connectionId,
-            read: notificationRecord.read,
-            groupReplied: true,
           },
-        },
-      });
+        });
+        this.props.eventEmitter.emit<NotificationAddedEvent>({
+          type: EventTypes.NotificationAdded,
+          payload: {
+            note: {
+              id: notificationRecord.id,
+              createdAt: notificationRecord.createdAt.toISOString(),
+              a: notificationRecord.a,
+              connectionId: notificationRecord.connectionId,
+              read: notificationRecord.read,
+              groupReplied: true,
+            },
+          },
+        });
 
-      return false;
-    }
-    case ExchangeRoute.IpexOffer: {
-      const applyExn = await this.props.signifyClient
-        .exchanges()
-        .get(exchange.exn.e.exn.p);
+        return false;
+      }
+      case ExchangeRoute.IpexOffer: {
+        const applyExn = await this.props.signifyClient
+          .exchanges()
+          .get(exchange.exn.e.exn.p);
 
-      const applyNotificationRecords =
+        const applyNotificationRecords =
           await this.notificationStorage.findAllByQuery({
             exnSaid: applyExn.exn.d,
           });
 
-      // Either relates to an processed and deleted apply notification, or is out of order
-      if (applyNotificationRecords.length === 0) {
-        const connectionInCloud =
+        // Either relates to an processed and deleted apply notification, or is out of order
+        if (applyNotificationRecords.length === 0) {
+          const connectionInCloud =
             await this.connectionService.getConnectionById(
               applyExn.exn.i,
               true
             );
-        const historyExists = connectionInCloud.historyItems.some(
-          (item) => item.id === applyExn.exn.d
-        );
-        if (historyExists) {
-          await this.markNotification(notif.i);
-          return false;
-        } else {
-          throw new Error(KeriaNotificationService.OUT_OF_ORDER_NOTIFICATION);
+          const historyExists = connectionInCloud.historyItems.some(
+            (item) => item.id === applyExn.exn.d
+          );
+          if (historyExists) {
+            await this.markNotification(notif.i);
+            return false;
+          } else {
+            throw new Error(KeriaNotificationService.OUT_OF_ORDER_NOTIFICATION);
+          }
         }
-      }
 
-      // Refresh the date and read status for UI, and link
-      const notificationRecord = applyNotificationRecords[0];
-      notificationRecord.linkedRequest = {
-        ...notificationRecord.linkedRequest,
-        current: exchange.exn.d,
-      };
-      notificationRecord.createdAt = new Date(notif.dt);
-      notificationRecord.read = false;
+        // Refresh the date and read status for UI, and link
+        const notificationRecord = applyNotificationRecords[0];
+        notificationRecord.linkedRequest = {
+          ...notificationRecord.linkedRequest,
+          current: exchange.exn.d,
+        };
+        notificationRecord.createdAt = new Date(notif.dt);
+        notificationRecord.read = false;
 
-      const { ourIdentifier, multisigMembers } =
+        const { ourIdentifier, multisigMembers } =
           await this.multiSigs.getMultisigParticipants(exchange.exn.a.gid);
 
-      notificationRecord.groupReplied = true;
-      notificationRecord.groupInitiatorPre = multisigMembers[0].aid;
-      notificationRecord.groupInitiator =
+        notificationRecord.groupReplied = true;
+        notificationRecord.groupInitiatorPre = multisigMembers[0].aid;
+        notificationRecord.groupInitiator =
           ourIdentifier.groupMetadata?.groupInitiator;
 
-      await this.notificationStorage.update(notificationRecord);
+        await this.notificationStorage.update(notificationRecord);
 
-      this.props.eventEmitter.emit<NotificationRemovedEvent>({
-        type: EventTypes.NotificationRemoved,
-        payload: {
-          id: notificationRecord.id,
-        },
-      });
-
-      this.props.eventEmitter.emit<NotificationAddedEvent>({
-        type: EventTypes.NotificationAdded,
-        payload: {
-          note: {
+        this.props.eventEmitter.emit<NotificationRemovedEvent>({
+          type: EventTypes.NotificationRemoved,
+          payload: {
             id: notificationRecord.id,
-            createdAt: notificationRecord.createdAt.toISOString(),
-            a: notificationRecord.a,
-            connectionId: notificationRecord.connectionId,
-            read: notificationRecord.read,
-            groupReplied: notificationRecord.groupReplied,
-            groupInitiatorPre: notificationRecord.groupInitiatorPre,
-            groupInitiator: notificationRecord.groupInitiator,
           },
-        },
-      });
+        });
 
-      return false;
-    }
-    case ExchangeRoute.IpexGrant: {
-      const agreeExn = await this.props.signifyClient
-        .exchanges()
-        .get(exchange.exn.e.exn.p);
+        this.props.eventEmitter.emit<NotificationAddedEvent>({
+          type: EventTypes.NotificationAdded,
+          payload: {
+            note: {
+              id: notificationRecord.id,
+              createdAt: notificationRecord.createdAt.toISOString(),
+              a: notificationRecord.a,
+              connectionId: notificationRecord.connectionId,
+              read: notificationRecord.read,
+              groupReplied: notificationRecord.groupReplied,
+              groupInitiatorPre: notificationRecord.groupInitiatorPre,
+              groupInitiator: notificationRecord.groupInitiator,
+            },
+          },
+        });
 
-      const agreeNotificationRecords =
+        return false;
+      }
+      case ExchangeRoute.IpexGrant: {
+        const agreeExn = await this.props.signifyClient
+          .exchanges()
+          .get(exchange.exn.e.exn.p);
+
+        const agreeNotificationRecords =
           await this.notificationStorage.findAllByQuery({
             exnSaid: agreeExn.exn.d,
           });
 
-      // Either relates to an processed and deleted agree notification, or is out of order
-      if (agreeNotificationRecords.length === 0) {
-        const connectionInCloud =
+        // Either relates to an processed and deleted agree notification, or is out of order
+        if (agreeNotificationRecords.length === 0) {
+          const connectionInCloud =
             await this.connectionService.getConnectionById(
               agreeExn.exn.i,
               true
             );
-        const historyExists = connectionInCloud.historyItems.some(
-          (item) => item.id === agreeExn.exn.d
-        );
-        if (historyExists) {
-          await this.markNotification(notif.i);
-          return false;
-        } else {
-          throw new Error(KeriaNotificationService.OUT_OF_ORDER_NOTIFICATION);
+          const historyExists = connectionInCloud.historyItems.some(
+            (item) => item.id === agreeExn.exn.d
+          );
+          if (historyExists) {
+            await this.markNotification(notif.i);
+            return false;
+          } else {
+            throw new Error(KeriaNotificationService.OUT_OF_ORDER_NOTIFICATION);
+          }
         }
+
+        // @TODO - foconnor: Could be optimised to only update record once but deviates from the other IPEX messages - OK for now.
+        const notificationRecord = agreeNotificationRecords[0];
+        notificationRecord.linkedRequest = {
+          ...notificationRecord.linkedRequest,
+          current: exchange.exn.d,
+        };
+
+        await this.notificationStorage.update(notificationRecord);
+        await this.ipexCommunications.joinMultisigGrant(
+          exchange,
+          notificationRecord
+        );
+
+        return false;
       }
-
-      // @TODO - foconnor: Could be optimised to only update record once but deviates from the other IPEX messages - OK for now.
-      const notificationRecord = agreeNotificationRecords[0];
-      notificationRecord.linkedRequest = {
-        ...notificationRecord.linkedRequest,
-        current: exchange.exn.d,
-      };
-
-      await this.notificationStorage.update(notificationRecord);
-      await this.ipexCommunications.joinMultisigGrant(
-        exchange,
-        notificationRecord
-      );
-
-      return false;
-    }
-    default:
-      return false;
+      default:
+        return false;
     }
   }
 
@@ -1025,42 +1021,42 @@ class KeriaNotificationService extends AgentService {
 
     if (operation.done && operation.error) {
       switch (operationRecord.recordType) {
-      case OperationPendingRecordType.Witness: {
-        await this.identifierStorage.updateIdentifierMetadata(recordId, {
-          creationStatus: CreationStatus.FAILED,
-        });
-        this.props.eventEmitter.emit<OperationFailedEvent>({
-          type: EventTypes.OperationFailed,
-          payload: {
-            opType: operationRecord.recordType,
-            oid: recordId,
-          },
-        });
-        break;
-      }
-      case OperationPendingRecordType.Oobi: {
-        const oobi = operation.metadata?.oobi?.split("/oobi/")[1];
-        const connectionId = oobi.includes("/") ? oobi.split("/")[0] : oobi;
-        const connectionRecord = await this.connectionStorage.findById(
-          connectionId
-        );
-
-        if (connectionRecord && !connectionRecord.pendingDeletion) {
-          connectionRecord.creationStatus = CreationStatus.FAILED;
-          await this.connectionStorage.update(connectionRecord);
+        case OperationPendingRecordType.Witness: {
+          await this.identifierStorage.updateIdentifierMetadata(recordId, {
+            creationStatus: CreationStatus.FAILED,
+          });
+          this.props.eventEmitter.emit<OperationFailedEvent>({
+            type: EventTypes.OperationFailed,
+            payload: {
+              opType: operationRecord.recordType,
+              oid: recordId,
+            },
+          });
+          break;
         }
-        this.props.eventEmitter.emit<OperationFailedEvent>({
-          type: EventTypes.OperationFailed,
-          payload: {
-            opType: operationRecord.recordType,
-            oid: connectionId,
-          },
-        });
-        break;
-      }
-      default: {
-        break;
-      }
+        case OperationPendingRecordType.Oobi: {
+          const oobi = operation.metadata?.oobi?.split("/oobi/")[1];
+          const connectionId = oobi.includes("/") ? oobi.split("/")[0] : oobi;
+          const connectionRecord = await this.connectionStorage.findById(
+            connectionId
+          );
+
+          if (connectionRecord && !connectionRecord.pendingDeletion) {
+            connectionRecord.creationStatus = CreationStatus.FAILED;
+            await this.connectionStorage.update(connectionRecord);
+          }
+          this.props.eventEmitter.emit<OperationFailedEvent>({
+            type: EventTypes.OperationFailed,
+            payload: {
+              opType: operationRecord.recordType,
+              oid: connectionId,
+            },
+          });
+          break;
+        }
+        default: {
+          break;
+        }
       }
 
       await this.operationPendingStorage.deleteById(operationRecord.id);
@@ -1074,242 +1070,250 @@ class KeriaNotificationService extends AgentService {
 
     if (operation.done) {
       switch (operationRecord.recordType) {
-      case OperationPendingRecordType.Group: {
-        await this.identifierStorage
-          .updateIdentifierMetadata(recordId, {
-            creationStatus: CreationStatus.COMPLETE,
-          })
-          .catch((error) => {
-            // In case user deleted pending identifier
-            if (
-              !(
-                error instanceof Error &&
-                  error.message.startsWith(
-                    IdentifierStorage.IDENTIFIER_METADATA_RECORD_MISSING
-                  )
-              )
-            ) {
-              throw error;
-            }
-          });
-        await this.multiSigs.endRoleAuthorization(recordId);
-        break;
-      }
-      case OperationPendingRecordType.Witness: {
-        await this.identifierStorage
-          .updateIdentifierMetadata(recordId, {
-            creationStatus: CreationStatus.COMPLETE,
-          })
-          .catch((error) => {
-            // In case user deleted pending identifier
-            if (
-              !(
-                error instanceof Error &&
-                  error.message.startsWith(
-                    IdentifierStorage.IDENTIFIER_METADATA_RECORD_MISSING
-                  )
-              )
-            ) {
-              throw error;
-            }
-          });
-        break;
-      }
-      case OperationPendingRecordType.Oobi: {
-        const connectionRecord = await this.connectionStorage.findById(
-          (operation.response as State).i
-        );
-
-        if (connectionRecord && !connectionRecord.pendingDeletion) {
-          connectionRecord.creationStatus = CreationStatus.COMPLETE;
-
-          const keriaContact = await this.props.signifyClient
-            .contacts()
-            .get((operation.response as State).i)
-            .catch(() => undefined);
-
-          if (!keriaContact) {
-            await this.props.signifyClient
-              .contacts()
-              .update((operation.response as State).i, {
-                alias: connectionRecord.alias,
-                createdAt: new Date((operation.response as State).dt),
-                oobi: connectionRecord.oobi,
-              });
-          }
-
-          await this.connectionStorage.update(connectionRecord);
-
-          this.props.eventEmitter.emit<ConnectionStateChangedEvent>({
-            type: EventTypes.ConnectionStateChanged,
-            payload: {
-              connectionId: connectionRecord.id,
-              status: ConnectionStatus.CONFIRMED,
-            },
-          });
-        }
-        break;
-      }
-      case OperationPendingRecordType.ExchangeReceiveCredential: {
-        const admitExchange = await this.props.signifyClient
-          .exchanges()
-          .get(operation.metadata?.said);
-        if (admitExchange.exn.r === ExchangeRoute.IpexAdmit) {
-          const grantExchange = await this.props.signifyClient
-            .exchanges()
-            .get(admitExchange.exn.p);
-          const credentialId = grantExchange.exn.e.acdc.d;
-
-          const notifications = await this.notificationStorage.findAllByQuery(
-            {
-              exnSaid: grantExchange.exn.d,
-            }
-          );
-
-          for (const notification of notifications) {
-            await deleteNotificationRecordById(
-              this.props.signifyClient,
-              this.notificationStorage,
-              notification.id,
-                notification.a.r as NotificationRoute
-            );
-
-            this.props.eventEmitter.emit<NotificationRemovedEvent>({
-              type: EventTypes.NotificationRemoved,
-              payload: {
-                id: notification.id,
-              },
-            });
-          }
-
-          await this.credentialService
-            .markAcdc(credentialId, CredentialStatus.CONFIRMED)
+        case OperationPendingRecordType.Group: {
+          await this.identifierStorage
+            .updateIdentifierMetadata(recordId, {
+              creationStatus: CreationStatus.COMPLETE,
+            })
             .catch((error) => {
-              // In case user deleted pending credential in UI
+              // In case user deleted pending identifier
               if (
                 !(
                   error instanceof Error &&
-                    error.message.startsWith(
-                      CredentialService.CREDENTIAL_MISSING_METADATA_ERROR_MSG
-                    )
+                  error.message.startsWith(
+                    IdentifierStorage.IDENTIFIER_METADATA_RECORD_MISSING
+                  )
                 )
               ) {
                 throw error;
               }
             });
-
-          await this.ipexCommunications.createLinkedIpexMessageRecord(
-            grantExchange,
-            ConnectionHistoryType.CREDENTIAL_ISSUANCE
-          );
+          await this.multiSigs.endRoleAuthorization(recordId);
+          break;
         }
-        break;
-      }
-      case OperationPendingRecordType.ExchangeOfferCredential: {
-        const offerExchange = await this.props.signifyClient
-          .exchanges()
-          .get(operation.metadata?.said);
-
-        if (offerExchange.exn.r === ExchangeRoute.IpexOffer) {
-          const applyExchange = await this.props.signifyClient
-            .exchanges()
-            .get(offerExchange.exn.p);
-
-          const holder = await this.identifierStorage.getIdentifierMetadata(
-            offerExchange.exn.i
+        case OperationPendingRecordType.Witness: {
+          await this.identifierStorage
+            .updateIdentifierMetadata(recordId, {
+              creationStatus: CreationStatus.COMPLETE,
+            })
+            .catch((error) => {
+              // In case user deleted pending identifier
+              if (
+                !(
+                  error instanceof Error &&
+                  error.message.startsWith(
+                    IdentifierStorage.IDENTIFIER_METADATA_RECORD_MISSING
+                  )
+                )
+              ) {
+                throw error;
+              }
+            });
+          break;
+        }
+        case OperationPendingRecordType.Oobi: {
+          const connectionRecord = await this.connectionStorage.findById(
+            (operation.response as State).i
           );
-          const notifications = await this.notificationStorage.findAllByQuery(
-            {
-              exnSaid: applyExchange.exn.d,
+
+          if (connectionRecord && !connectionRecord.pendingDeletion) {
+            if (connectionRecord.sharedIdentifier) {
+              await this.connectionService.shareIdentifier(
+                connectionRecord.id,
+                connectionRecord.sharedIdentifier
+              );
             }
-          );
 
-          for (const notification of notifications) {
-            if (!holder.groupMemberPre) {
+            connectionRecord.creationStatus = CreationStatus.COMPLETE;
+
+            const keriaContact = await this.props.signifyClient
+              .contacts()
+              .get((operation.response as State).i)
+              .catch(() => undefined);
+
+            if (!keriaContact) {
+              await this.props.signifyClient
+                .contacts()
+                .update((operation.response as State).i, {
+                  alias: connectionRecord.alias,
+                  createdAt: new Date((operation.response as State).dt),
+                  oobi: connectionRecord.oobi,
+                  sharedIdentifier: connectionRecord.sharedIdentifier ?? "",
+                });
+            }
+
+            await this.connectionStorage.update(connectionRecord);
+
+            this.props.eventEmitter.emit<ConnectionStateChangedEvent>({
+              type: EventTypes.ConnectionStateChanged,
+              payload: {
+                connectionId: connectionRecord.id,
+                status: ConnectionStatus.CONFIRMED,
+              },
+            });
+          }
+          break;
+        }
+        case OperationPendingRecordType.ExchangeReceiveCredential: {
+          const admitExchange = await this.props.signifyClient
+            .exchanges()
+            .get(operation.metadata?.said);
+          if (admitExchange.exn.r === ExchangeRoute.IpexAdmit) {
+            const grantExchange = await this.props.signifyClient
+              .exchanges()
+              .get(admitExchange.exn.p);
+            const credentialId = grantExchange.exn.e.acdc.d;
+
+            const notifications = await this.notificationStorage.findAllByQuery(
+              {
+                exnSaid: grantExchange.exn.d,
+              }
+            );
+
+            for (const notification of notifications) {
               await deleteNotificationRecordById(
                 this.props.signifyClient,
                 this.notificationStorage,
                 notification.id,
-                  notification.a.r as NotificationRoute
+                notification.a.r as NotificationRoute
               );
-              continue;
+
+              this.props.eventEmitter.emit<NotificationRemovedEvent>({
+                type: EventTypes.NotificationRemoved,
+                payload: {
+                  id: notification.id,
+                },
+              });
             }
 
-            // "Refresh" the notification so user is aware offer is successfully sent
-            notification.createdAt = new Date();
-            notification.read = false;
+            await this.credentialService
+              .markAcdc(credentialId, CredentialStatus.CONFIRMED)
+              .catch((error) => {
+                // In case user deleted pending credential in UI
+                if (
+                  !(
+                    error instanceof Error &&
+                    error.message.startsWith(
+                      CredentialService.CREDENTIAL_MISSING_METADATA_ERROR_MSG
+                    )
+                  )
+                ) {
+                  throw error;
+                }
+              });
 
-            const { multisigMembers, ourIdentifier } =
+            await this.ipexCommunications.createLinkedIpexMessageRecord(
+              grantExchange,
+              ConnectionHistoryType.CREDENTIAL_ISSUANCE
+            );
+          }
+          break;
+        }
+        case OperationPendingRecordType.ExchangeOfferCredential: {
+          const offerExchange = await this.props.signifyClient
+            .exchanges()
+            .get(operation.metadata?.said);
+
+          if (offerExchange.exn.r === ExchangeRoute.IpexOffer) {
+            const applyExchange = await this.props.signifyClient
+              .exchanges()
+              .get(offerExchange.exn.p);
+
+            const holder = await this.identifierStorage.getIdentifierMetadata(
+              offerExchange.exn.i
+            );
+            const notifications = await this.notificationStorage.findAllByQuery(
+              {
+                exnSaid: applyExchange.exn.d,
+              }
+            );
+
+            for (const notification of notifications) {
+              if (!holder.groupMemberPre) {
+                await deleteNotificationRecordById(
+                  this.props.signifyClient,
+                  this.notificationStorage,
+                  notification.id,
+                  notification.a.r as NotificationRoute
+                );
+                continue;
+              }
+
+              // "Refresh" the notification so user is aware offer is successfully sent
+              notification.createdAt = new Date();
+              notification.read = false;
+
+              const { multisigMembers, ourIdentifier } =
                 await this.multiSigs.getMultisigParticipants(
                   applyExchange.exn.rp
                 );
 
-            notification.groupReplied = true;
-            notification.groupInitiatorPre = multisigMembers[0].aid;
-            notification.groupInitiator =
+              notification.groupReplied = true;
+              notification.groupInitiatorPre = multisigMembers[0].aid;
+              notification.groupInitiator =
                 ourIdentifier.groupMetadata!.groupInitiator;
 
-            await this.notificationStorage.update(notification);
+              await this.notificationStorage.update(notification);
 
-            this.props.eventEmitter.emit<NotificationRemovedEvent>({
-              type: EventTypes.NotificationRemoved,
-              payload: {
-                id: notification.id,
-              },
-            });
-
-            this.props.eventEmitter.emit<NotificationAddedEvent>({
-              type: EventTypes.NotificationAdded,
-              payload: {
-                note: {
+              this.props.eventEmitter.emit<NotificationRemovedEvent>({
+                type: EventTypes.NotificationRemoved,
+                payload: {
                   id: notification.id,
-                  createdAt: notification.createdAt.toISOString(),
-                  a: notification.a,
-                  connectionId: notification.connectionId,
-                  read: notification.read,
-                  groupReplied: notification.groupReplied,
-                  groupInitiatorPre: notification.groupInitiatorPre,
-                  groupInitiator: notification.groupInitiator,
                 },
-              },
-            });
-          }
-        }
-        break;
-      }
-      case OperationPendingRecordType.ExchangePresentCredential: {
-        const grantExchange = await this.props.signifyClient
-          .exchanges()
-          .get(operation.metadata?.said);
-        if (grantExchange.exn.r === ExchangeRoute.IpexGrant) {
-          const agreeExchange = await this.props.signifyClient
-            .exchanges()
-            .get(grantExchange.exn.p);
+              });
 
-          const notifications = await this.notificationStorage.findAllByQuery(
-            {
-              exnSaid: agreeExchange.exn.d,
+              this.props.eventEmitter.emit<NotificationAddedEvent>({
+                type: EventTypes.NotificationAdded,
+                payload: {
+                  note: {
+                    id: notification.id,
+                    createdAt: notification.createdAt.toISOString(),
+                    a: notification.a,
+                    connectionId: notification.connectionId,
+                    read: notification.read,
+                    groupReplied: notification.groupReplied,
+                    groupInitiatorPre: notification.groupInitiatorPre,
+                    groupInitiator: notification.groupInitiator,
+                  },
+                },
+              });
             }
-          );
-          for (const notification of notifications) {
-            await deleteNotificationRecordById(
-              this.props.signifyClient,
-              this.notificationStorage,
-              notification.id,
+          }
+          break;
+        }
+        case OperationPendingRecordType.ExchangePresentCredential: {
+          const grantExchange = await this.props.signifyClient
+            .exchanges()
+            .get(operation.metadata?.said);
+          if (grantExchange.exn.r === ExchangeRoute.IpexGrant) {
+            const agreeExchange = await this.props.signifyClient
+              .exchanges()
+              .get(grantExchange.exn.p);
+
+            const notifications = await this.notificationStorage.findAllByQuery(
+              {
+                exnSaid: agreeExchange.exn.d,
+              }
+            );
+            for (const notification of notifications) {
+              await deleteNotificationRecordById(
+                this.props.signifyClient,
+                this.notificationStorage,
+                notification.id,
                 notification.a.r as NotificationRoute
+              );
+            }
+
+            await this.ipexCommunications.createLinkedIpexMessageRecord(
+              grantExchange,
+              ConnectionHistoryType.CREDENTIAL_PRESENTED
             );
           }
-
-          await this.ipexCommunications.createLinkedIpexMessageRecord(
-            grantExchange,
-            ConnectionHistoryType.CREDENTIAL_PRESENTED
-          );
+          break;
         }
-        break;
-      }
-      default: {
-        break;
-      }
+        default: {
+          break;
+        }
       }
 
       this.props.eventEmitter.emit<OperationCompleteEvent>({

--- a/src/ui/components/InputRequest/InputRequest.tsx
+++ b/src/ui/components/InputRequest/InputRequest.tsx
@@ -26,6 +26,7 @@ import { ErrorMessage } from "../ErrorMessage";
 import { TabsRoutePath } from "../navigation/TabsMenu";
 import { PageFooter } from "../PageFooter";
 import "./InputRequest.scss";
+import { OobiQueryParams } from "../../../core/agent/services/connectionService.types";
 
 const InputRequest = () => {
   const dispatch = useAppDispatch();
@@ -137,7 +138,7 @@ const InputRequest = () => {
     if (missingAliasUrl) {
       if (!missingAliasUrl) return;
       const url = new URL(missingAliasUrl);
-      url.searchParams.set("name", inputValue);
+      url.searchParams.set(OobiQueryParams.NAME, inputValue);
       resolveConnectionOobi(url.toString());
       dispatch(setMissingAliasUrl(undefined));
       setInputValue("");

--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -70,6 +70,7 @@ import { OptionModal } from "../OptionsModal";
 import { PageFooter } from "../PageFooter";
 import "./Scanner.scss";
 import { ErrorMessage, ScannerProps } from "./Scanner.types";
+import { OobiQueryParams } from "../../../core/agent/services/connectionService.types";
 
 const OPEN_CONNECTION_TIME = 250;
 
@@ -346,7 +347,7 @@ const Scanner = forwardRef(
     ) => {
       let urlId: string | null = null;
       if (isMultisig) {
-        urlId = new URL(url).searchParams.get("groupId");
+        urlId = new URL(url).searchParams.get(OobiQueryParams.GROUP_ID);
       } else {
         urlId = e.message
           .replace(StorageMessage.RECORD_ALREADY_EXISTS_ERROR_MSG, "")
@@ -387,8 +388,10 @@ const Scanner = forwardRef(
     };
 
     const checkUrl = (url: string) => {
-      const isMultiSigUrl = url.includes("groupId");
-      const urlGroupId = new URL(url).searchParams.get("groupId");
+      const isMultiSigUrl = url.includes(OobiQueryParams.GROUP_ID);
+      const urlGroupId = new URL(url).searchParams.get(
+        OobiQueryParams.GROUP_ID
+      );
       const openScanFromMultiSig = [
         OperationType.MULTI_SIG_INITIATOR_SCAN,
         OperationType.MULTI_SIG_RECEIVER_SCAN,
@@ -424,7 +427,9 @@ const Scanner = forwardRef(
 
         if (invitation.type === OobiType.NORMAL) {
           setIsValueCaptured && setIsValueCaptured(true);
-          const groupId = new URL(content).searchParams.get("groupId");
+          const groupId = new URL(content).searchParams.get(
+            OobiQueryParams.GROUP_ID
+          );
 
           if (
             currentOperation === OperationType.MULTI_SIG_INITIATOR_SCAN ||
@@ -490,7 +495,9 @@ const Scanner = forwardRef(
     const resolveConnectionOobi = async (content: string) => {
       // Adding a pending connection item to the UI.
       // This will be removed when the create connection process ends.
-      const connectionName = new URL(content).searchParams.get("name");
+      const connectionName = new URL(content).searchParams.get(
+        OobiQueryParams.NAME
+      );
       if (!connectionName) {
         setTimeout(() => {
           dispatch(setMissingAliasUrl(content));
@@ -528,7 +535,7 @@ const Scanner = forwardRef(
     };
 
     const handleResolveOobi = async (content: string) => {
-      const isMultisigUrl = content.includes("groupId");
+      const isMultisigUrl = content.includes(OobiQueryParams.GROUP_ID);
 
       try {
         if (!isMultisigUrl) {
@@ -594,50 +601,50 @@ const Scanner = forwardRef(
 
     const RenderPageFooter = () => {
       switch (currentOperation) {
-      case OperationType.SCAN_WALLET_CONNECTION:
-        return (
-          <PageFooter
-            customClass="actions-button"
-            secondaryButtonAction={openPasteModal}
-            secondaryButtonText={`${i18n.t("tabs.scan.pastemeerkatid")}`}
-          />
-        );
-      case OperationType.MULTI_SIG_INITIATOR_SCAN:
-        return (
-          <PageFooter
-            pageId={componentId}
-            primaryButtonText={`${i18n.t("createidentifier.scan.initiate")}`}
-            primaryButtonAction={handlePrimaryButtonAction}
-            primaryButtonDisabled={!multiSigGroupCache?.connections.length}
-            secondaryButtonText={`${i18n.t(
-              "createidentifier.scan.pasteoobi"
-            )}`}
-            secondaryButtonAction={openPasteModal}
-          />
-        );
-      case OperationType.MULTI_SIG_RECEIVER_SCAN:
-        return (
-          <PageFooter
-            pageId={componentId}
-            secondaryButtonText={`${i18n.t(
-              "createidentifier.scan.pasteoobi"
-            )}`}
-            secondaryButtonAction={openPasteModal}
-          />
-        );
-      case OperationType.SCAN_SSI_BOOT_URL:
-      case OperationType.SCAN_SSI_CONNECT_URL:
-        return <div></div>;
-      default:
-        return (
-          <PageFooter
-            pageId={componentId}
-            secondaryButtonText={`${i18n.t(
-              "createidentifier.scan.pastecontents"
-            )}`}
-            secondaryButtonAction={openPasteModal}
-          />
-        );
+        case OperationType.SCAN_WALLET_CONNECTION:
+          return (
+            <PageFooter
+              customClass="actions-button"
+              secondaryButtonAction={openPasteModal}
+              secondaryButtonText={`${i18n.t("tabs.scan.pastemeerkatid")}`}
+            />
+          );
+        case OperationType.MULTI_SIG_INITIATOR_SCAN:
+          return (
+            <PageFooter
+              pageId={componentId}
+              primaryButtonText={`${i18n.t("createidentifier.scan.initiate")}`}
+              primaryButtonAction={handlePrimaryButtonAction}
+              primaryButtonDisabled={!multiSigGroupCache?.connections.length}
+              secondaryButtonText={`${i18n.t(
+                "createidentifier.scan.pasteoobi"
+              )}`}
+              secondaryButtonAction={openPasteModal}
+            />
+          );
+        case OperationType.MULTI_SIG_RECEIVER_SCAN:
+          return (
+            <PageFooter
+              pageId={componentId}
+              secondaryButtonText={`${i18n.t(
+                "createidentifier.scan.pasteoobi"
+              )}`}
+              secondaryButtonAction={openPasteModal}
+            />
+          );
+        case OperationType.SCAN_SSI_BOOT_URL:
+        case OperationType.SCAN_SSI_CONNECT_URL:
+          return <div></div>;
+        default:
+          return (
+            <PageFooter
+              pageId={componentId}
+              secondaryButtonText={`${i18n.t(
+                "createidentifier.scan.pastecontents"
+              )}`}
+              secondaryButtonAction={openPasteModal}
+            />
+          );
       }
     };
 


### PR DESCRIPTION
## Description

This allows us to forward an OOBI to a new contact using the `/introduce` reply message. It will only work for KERIA agents that opt into it.

The `externalId` query param is also forwarded in our OOBI URL if it was in the contacts. This means the query param can contain a unique ID which could be shared embedded in an OOBI for a service via email. This allows the service to associate users (by email) with their wallet. This is just a temporary solution and a real solution should use proper KYC etc, since the email becomes a shared secret.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2151)]

### Testing & Validation

- [X] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [X] Added new Unit/Component testing (if relevant).