### PR TITLE
fix(ui): Missing the QR screen after creating a group identifier

### DIFF
--- a/src/ui/pages/Identifiers/Identifiers.tsx
+++ b/src/ui/pages/Identifiers/Identifiers.tsx
@@ -353,7 +353,7 @@ const Identifiers = () => {
         }
         placeholder={
           showWelcomePage ? (
-            <Welcome />
+            <Welcome onCreateGroupIdentifier={handleMultiSigClick} />
           ) : (
             showPlaceholder && (
               <CardsPlaceholder

--- a/src/ui/pages/Identifiers/components/Welcome/Welcome.tsx
+++ b/src/ui/pages/Identifiers/components/Welcome/Welcome.tsx
@@ -17,7 +17,11 @@ import { Agent } from "../../../../../core/agent/agent";
 import { MiscRecordId } from "../../../../../core/agent/agent.types";
 import { IdentifierShortDetails } from "../../../../../core/agent/services/identifier.types";
 
-const Welcome = () => {
+interface WelcomeProps {
+  onCreateGroupIdentifier?: (identifier: IdentifierShortDetails) => void;
+}
+
+const Welcome = ({ onCreateGroupIdentifier }: WelcomeProps) => {
   const pageId = "welcome";
   const auth = useAppSelector(getAuthentication);
   const dispatch = useAppDispatch();
@@ -34,6 +38,9 @@ const Welcome = () => {
 
   const handleCloseModal = (identifier?: IdentifierShortDetails) => {
     if (identifier) {
+      if (identifier.groupMetadata) {
+        onCreateGroupIdentifier?.(identifier);
+      }
       skip();
     }
 


### PR DESCRIPTION
## Description

Fix missing the QR screen after creating a group identifier

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-2169)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Browser

https://github.com/user-attachments/assets/f038b613-230d-42ab-b4dd-30c921467dfc

