### PR TITLE
fix(ui): unable to access camera if scan an unrecognized QR

### DIFF
--- a/src/ui/components/Scanner/Scanner.tsx
+++ b/src/ui/components/Scanner/Scanner.tsx
@@ -184,22 +184,25 @@ const Scanner = forwardRef(
             ToastMsgType.CREDENTIAL_REQUEST_PENDING,
           ].includes(item.message)
         );
-
+        const isFullPageScan = !routePath;
         const isScanning =
           routePath === TabsRoutePath.SCAN ||
-          [
-            OperationType.SCAN_CONNECTION,
-            OperationType.SCAN_REMOTE_CONNECTION,
-            OperationType.SCAN_WALLET_CONNECTION,
-            OperationType.SCAN_SSI_BOOT_URL,
-            OperationType.SCAN_SSI_CONNECT_URL,
-          ].includes(currentOperation);
+          (isFullPageScan &&
+            [
+              OperationType.SCAN_CONNECTION,
+              OperationType.SCAN_REMOTE_CONNECTION,
+              OperationType.SCAN_WALLET_CONNECTION,
+              OperationType.SCAN_SSI_BOOT_URL,
+              OperationType.SCAN_SSI_CONNECT_URL,
+            ].includes(currentOperation));
 
         const isMultisignScan =
+          isFullPageScan &&
           [
             OperationType.MULTI_SIG_INITIATOR_SCAN,
             OperationType.MULTI_SIG_RECEIVER_SCAN,
-          ].includes(currentOperation) && !isDuplicateConnectionToast;
+          ].includes(currentOperation) &&
+          !isDuplicateConnectionToast;
 
         if ((isScanning && !isRequestPending) || isMultisignScan) {
           await initScan();


### PR DESCRIPTION
## Description

Fix camera cannot access after scan QR. Scan tab still exist on DOM after we nav to another tab. If we scan other QR by `FullPageScan`, Scan tab and current tab call function to init camera together and sometime it make this issue.

<img width="618" alt="Screenshot 2025-04-22 at 16 50 52" src="https://github.com/user-attachments/assets/a242dbff-50cd-4b7e-9de2-e85442d1328d" />


## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-2142)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Android

https://github.com/user-attachments/assets/cd6ae6c4-729e-45d9-b209-7630ba678d56

