### PR TITLE
feat(ui): Complete remote signing UI with real data

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1865,7 +1865,8 @@
     "proposalcredreject": "Credential proposal rejected",
     "proposalcredfailerror": "Unable to record response",
     "deleteaccounterror": "Unable to delete account",
-    "deleteaccountsuccess": "Account deleted successfully"
+    "deleteaccountsuccess": "Account deleted successfully",
+    "remotesignsuccess": "Certificate signed successfully"
   },
   "request": {
     "sign": {

--- a/src/ui/globals/types.ts
+++ b/src/ui/globals/types.ts
@@ -82,6 +82,7 @@ enum ToastMsgType {
   GROUP_ID_NOT_MATCH_ERROR = "groupidnotmatcherror",
   DELETE_ACCOUNT_ERROR = "deleteaccounterror",
   DELETE_ACCOUNT_SUCCESS = "deleteaccountsuccess",
+  REMOTE_SIGN_SUCCESS = "remotesignsuccess",
   UNKNOWN_ERROR = "unknownerror",
 }
 

--- a/src/ui/pages/NotificationDetails/components/RemoteSignRequest/RemoteSignRequest.test.tsx
+++ b/src/ui/pages/NotificationDetails/components/RemoteSignRequest/RemoteSignRequest.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import EN_TRANSLATIONS from "../../../../../locales/en/en.json";
@@ -7,9 +7,38 @@ import { connectionsForNotifications } from "../../../../__fixtures__/connection
 import { filteredIdentifierMapFix } from "../../../../__fixtures__/filteredIdentifierFix";
 import { notificationsFix } from "../../../../__fixtures__/notificationsFix";
 import { RemoteSignRequest } from "./RemoteSignRequest";
+import { passcodeFiller } from "../../../../utils/passcodeFiller";
 
 const mockStore = configureStore();
 const dispatchMock = jest.fn();
+
+const remoteSignMock = jest.fn();
+const getRemoteSignRequestDetailsMock = jest.fn(() => ({
+  identifier: "ENuh2aOh3ZpZhvIdz2zJbdpUllatrArTUN8A_-BWxWGc",
+  payload: {
+    t: 8,
+  },
+}));
+
+jest.mock("../../../../../core/agent/agent", () => ({
+  Agent: {
+    agent: {
+      identifiers: {
+        remoteSign: () => remoteSignMock(),
+        getRemoteSignRequestDetails: () => getRemoteSignRequestDetailsMock(),
+      },
+      auth: {
+        verifySecret: jest.fn().mockResolvedValue(true),
+      },
+    },
+  },
+}));
+
+jest.mock("@ionic/react", () => ({
+  ...jest.requireActual("@ionic/react"),
+  IonModal: ({ children, isOpen, ...props }: any) =>
+    isOpen ? <div data-testid={props["data-testid"]}>{children}</div> : null,
+}));
 
 const initialState = {
   stateCache: {
@@ -84,5 +113,41 @@ describe("Receive credential", () => {
         EN_TRANSLATIONS.tabs.notifications.details.sign.transaction.data
       )
     ).toBeVisible();
+    await waitFor(() => {
+      expect(getByText("ENuh2aOh..._-BWxWGc")).toBeVisible();
+    });
+  });
+
+  test("Sign remote request", async () => {
+    const storeMocked = {
+      ...mockStore(initialState),
+      dispatch: dispatchMock,
+    };
+
+    const { getByText, getByTestId } = render(
+      <Provider store={storeMocked}>
+        <RemoteSignRequest
+          pageId="creadential-request"
+          activeStatus
+          handleBack={jest.fn()}
+          notificationDetails={notificationsFix[7]}
+        />
+      </Provider>
+    );
+    await waitFor(() => {
+      expect(getByText("ENuh2aOh..._-BWxWGc")).toBeVisible();
+    });
+
+    fireEvent.click(getByText(EN_TRANSLATIONS.request.button.sign));
+
+    await waitFor(() => {
+      expect(getByText(EN_TRANSLATIONS.verifypasscode.title)).toBeVisible();
+    });
+
+    passcodeFiller(getByText, getByTestId, "193212");
+
+    await waitFor(() => {
+      expect(remoteSignMock).toBeCalled();
+    });
   });
 });

--- a/src/ui/pages/NotificationDetails/components/RemoteSignRequest/RemoteSignRequest.tsx
+++ b/src/ui/pages/NotificationDetails/components/RemoteSignRequest/RemoteSignRequest.tsx
@@ -1,4 +1,5 @@
 import { IonIcon, IonText } from "@ionic/react";
+import { t } from "i18next";
 import {
   chevronDownOutline,
   chevronUpOutline,
@@ -6,9 +7,10 @@ import {
   personCircleOutline,
 } from "ionicons/icons";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { t } from "i18next";
+import { Agent } from "../../../../../core/agent/agent";
+import { RemoteSignRequest as RemoteSignRequestModel } from "../../../../../core/agent/services/identifier.types";
 import { i18n } from "../../../../../i18n";
-import { useAppSelector } from "../../../../../store/hooks";
+import { useAppDispatch, useAppSelector } from "../../../../../store/hooks";
 import { getConnectionsCache } from "../../../../../store/reducers/connectionsCache";
 import {
   CardBlock,
@@ -19,10 +21,15 @@ import { reservedKeysFilter } from "../../../../components/CardDetails/CardDetai
 import { ScrollablePageLayout } from "../../../../components/layout/ScrollablePageLayout";
 import { PageFooter } from "../../../../components/PageFooter";
 import { PageHeader } from "../../../../components/PageHeader";
+import { Spinner } from "../../../../components/Spinner";
+import { SpinnerConverage } from "../../../../components/Spinner/Spinner.type";
 import { Verification } from "../../../../components/Verification";
+import { showError } from "../../../../utils/error";
 import { combineClassNames } from "../../../../utils/style";
 import { NotificationDetailsProps } from "../../NotificationDetails.types";
 import "./RemoteSignRequest.scss";
+import { setToastMsg } from "../../../../../store/reducers/stateCache";
+import { ToastMsgType } from "../../../../globals/types";
 
 function ellipsisText(text: string) {
   return `${text.substring(0, 8)}...${text.slice(-8)}`;
@@ -34,6 +41,7 @@ const RemoteSignRequest = ({
   notificationDetails,
   handleBack,
 }: NotificationDetailsProps) => {
+  const dispatch = useAppDispatch();
   const connections = useAppSelector(getConnectionsCache);
   const [isSigningObject, setIsSigningObject] = useState(false);
   const [verifyIsOpen, setVerifyIsOpen] = useState(false);
@@ -41,8 +49,29 @@ const RemoteSignRequest = ({
   const [displayExpandButton, setDisplayExpandButton] = useState(false);
   const attributeContainerRef = useRef<HTMLDivElement>(null);
   const attributeRef = useRef<HTMLDivElement>(null);
-  const requestData = notificationDetails.a.payload as Record<string, string>;
   const connectionName = connections[notificationDetails.connectionId];
+  const [requestData, setRequestData] = useState<RemoteSignRequestModel>();
+  const [loading, showLoading] = useState(true);
+
+  useEffect(() => {
+    const getSignData = async () => {
+      try {
+        showLoading(true);
+        const requestData =
+          await Agent.agent.identifiers.getRemoteSignRequestDetails(
+            notificationDetails.a.d as string
+          );
+        setRequestData(requestData);
+      } catch (e) {
+        showError("Failed to get sign data", e, dispatch);
+        handleBack();
+      } finally {
+        showLoading(false);
+      }
+    };
+
+    getSignData();
+  }, [dispatch, handleBack, notificationDetails.a.d]);
 
   const signDetails = useMemo(() => {
     if (!requestData?.payload) {
@@ -51,10 +80,14 @@ const RemoteSignRequest = ({
 
     let signContent;
     try {
-      signContent = JSON.parse(requestData.payload);
+      signContent = requestData.payload;
+      if (signContent["id"]) {
+        signContent["id"] = ellipsisText(`${signContent["id"]}`);
+      }
 
-      signContent["id"] = ellipsisText(signContent["id"]);
-      signContent["address"] = ellipsisText(signContent["address"]);
+      if (signContent["address"]) {
+        signContent["address"] = ellipsisText(`${signContent["address"]}`);
+      }
 
       setIsSigningObject(true);
     } catch (error) {
@@ -63,8 +96,20 @@ const RemoteSignRequest = ({
     return signContent;
   }, [requestData]);
 
-  const handleSign = () => {
-    handleBack();
+  const handleSign = async () => {
+    try {
+      showLoading(true);
+      await Agent.agent.identifiers.remoteSign(
+        notificationDetails.id,
+        notificationDetails.a.d as string
+      );
+      dispatch(setToastMsg(ToastMsgType.REMOTE_SIGN_SUCCESS));
+      handleBack();
+    } catch (e) {
+      showError("Failed to sign", e, dispatch);
+    } finally {
+      showLoading(false);
+    }
   };
 
   const itemProps = useCallback((key?: string) => {
@@ -137,7 +182,11 @@ const RemoteSignRequest = ({
         customClass="custom-sign-request"
         header={
           <PageHeader
-            onBack={handleBack}
+            closeButton
+            closeButtonLabel={`${t(
+              "tabs.notifications.details.buttons.close"
+            )}`}
+            closeButtonAction={handleBack}
             title={`${t("tabs.notifications.details.sign.title", {
               certificate: "CSO Certificate", // TODO: change hardcoded value to dynamic
             })}`}
@@ -173,7 +222,7 @@ const RemoteSignRequest = ({
             className="sign-identifier"
           >
             <CardDetailsItem
-              info={ellipsisText(requestData.identifier || "")}
+              info={ellipsisText(requestData?.identifier || "")}
               icon={keyOutline}
               testId="identifier-id"
               className="identifier-id"
@@ -220,6 +269,10 @@ const RemoteSignRequest = ({
           </CardBlock>
         </div>
       </ScrollablePageLayout>
+      <Spinner
+        show={loading}
+        coverage={SpinnerConverage.Screen}
+      />
       <Verification
         verifyIsOpen={verifyIsOpen}
         setVerifyIsOpen={setVerifyIsOpen}


### PR DESCRIPTION
## Description

Complete remote signing UI with real data.
Steps to get notification:
- run `docker compose up -d`
- Go to this branch of our fork: https://github.com/cardano-foundation/signify-ts/tree/build/v1.1
- Create a new examples/integration-scripts/remoteSigning.test.tsx file
- Flow:
   - Create identifier in our wallet
   - Use Signify-TS script to create an agent and a new identifier and OOBI
   - Add the OOBI as a connection in the wallet on my branch
   - Use a different Signify-TS script to use the same identifier to send a remote signing request
```
    const hab = await client1.identifiers().get('alice');
    const payload = { d: "d&n", t: 2 };
    const [_, ked] = Saider.saidify(payload);
    await client1.exchanges().send(
        'alice',
        'remotesign',
        hab,
        '/remotesign/ixn/req',
        ked,
        [],
        ["EFS5uDlGHEEcEJ4MHXo7lRAFndqnc_ziC_a_OD3HlYMY"]
    );
```
  - `EFS5uDlGHEEcEJ4MHXo7lRAFndqnc_ziC_a_OD3HlYMY` is the identifier ID in the wallet and `alice` is identifier's alias of `client` in Signify .
  - NOTE: Each script needs to use the same bran/passcode to access the same identifier in each script. We need to do this or the wallet won’t accept remote signing requests from unknown identifiers.
 
## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [link](https://cardanofoundation.atlassian.net/browse/DTIS-2189)

### Testing & Validation

- [x] This PR has been tested/validated in IOS, Android and browser.
- [x] The code has been tested locally with test coverage match expectations.
- [x] Added new Unit/Component testing (if relevant).

### Security

- [x] No secrets are being committed (i.e. credentials, PII)
- [x] This PR does not have any significant security implications

### Code Review

- [x] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [x] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [x] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [x] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### Browser

https://github.com/user-attachments/assets/fe267e72-de16-41cc-8d2d-b969dc71d254
