### PR TITLE
feat: remove deviceid threat check (incorrect)

### DIFF
--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1924,7 +1924,6 @@
     "obfuscationissues": "Obfuscation Issues",
     "developermode": "Developer Mode",
     "adbenabled": "ADB Enabled",
-    "deviceId": "Device ID Issues",
     "alert": "Please, close and reopen the app to continue.",
     "help": "Help",
     "rules": {
@@ -1939,7 +1938,6 @@
       "obfuscationissues": "Indicates potential issues with code obfuscation, which is a security measure used to protect the app's code from reverse engineering. Lack of proper obfuscation increases security risks, especially on Android.",
       "developermode": "Detects if the device has developer mode enabled, which may indicate an increased risk of debugging or modification attempts, particularly on Android.",
       "adbenabled": "Indicates whether Android Debug Bridge (ADB) is enabled on the device, which can allow unauthorized access or debugging of the app.",
-      "deviceid": "Ensures that the device ID remains consistent. Unexpected changes in the device ID may indicate a security risk, such as device cloning or manipulation."
     }
   }
 }

--- a/src/locales/en/en.json
+++ b/src/locales/en/en.json
@@ -1937,7 +1937,7 @@
       "securehardwarenotavailable": "Indicates that secure hardware features, such as a secure enclave or trusted execution environment (TEE), are unavailable. While this may be tolerable in some cases, it can reduce security.",
       "obfuscationissues": "Indicates potential issues with code obfuscation, which is a security measure used to protect the app's code from reverse engineering. Lack of proper obfuscation increases security risks, especially on Android.",
       "developermode": "Detects if the device has developer mode enabled, which may indicate an increased risk of debugging or modification attempts, particularly on Android.",
-      "adbenabled": "Indicates whether Android Debug Bridge (ADB) is enabled on the device, which can allow unauthorized access or debugging of the app.",
+      "adbenabled": "Indicates whether Android Debug Bridge (ADB) is enabled on the device, which can allow unauthorized access or debugging of the app."
     }
   }
 }

--- a/src/security/freerasp.ts
+++ b/src/security/freerasp.ts
@@ -19,7 +19,6 @@ export enum ThreatName {
   OBFUSCATION_ISSUES = "Obfuscation Issues",
   DEVELOPER_MODE = "Developer Mode",
   ADB_ENABLED = "ADB Enabled",
-  DEVICE_ID = "Device ID",
 }
 
 export interface ThreatCheck {
@@ -117,11 +116,8 @@ export const initializeFreeRASP = async (
     devMode: () => {},
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     adbEnabled: () => {},
-    deviceID: createThreatAction(
-      setThreatsDetected,
-      ThreatName.DEVICE_ID,
-      i18n.t("systemthreats.rules.deviceid")
-    ),
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    deviceID: () => {},
   };
 
   const freeRASPConfig = {


### PR DESCRIPTION
## Description

This should never have been in the list of threats. The device ID can change if you uninstall the app completely and re-install, which is not a threat in our case. We have no other reaction to make to this either.