### PR TITLE
fix(cred-serv): insert createdAt date as now (temp solution)

### DIFF
--- a/services/credential-server/src/modules/signify/signifyApi.ts
+++ b/services/credential-server/src/modules/signify/signifyApi.ts
@@ -6,6 +6,7 @@ import {
   Saider,
   Serder,
   State,
+  Contact,
 } from "signify-ts";
 import { waitAndGetDoneOp } from "./utils";
 import { config } from "../../config";
@@ -324,8 +325,20 @@ export class SignifyApi {
     await this.client.ipex().submitApply(senderName, apply, sigs, [recipient]);
   }
 
-  async contacts(): Promise<any> {
-    return this.client.contacts().list();
+  async contacts(): Promise<Contact[]> {
+    // @TODO - foconnor: Temporary hack to add createdAt after one-way scan, doing this now
+    // to avoid updating keripy and making a change which might make backwards compatability or migrations harder later.
+    const contacts = await this.client.contacts().list();
+    for (const contact of contacts) {
+      if (!contact.createdAt) {
+        contact.createdAt = new Date();
+        this.client.contacts().update(contact.id, {
+          createdAt: contact.createdAt,
+        });
+      }
+    }
+
+    return contacts;
   }
 
   async deleteContact(id: string): Promise<any> {

--- a/services/credential-server/src/routes.ts
+++ b/services/credential-server/src/routes.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import express, { Router } from "express";
 import { config } from "./config";
 import { ping } from "./apis/ping.api";
 import { keriOobiApi } from "./apis/invitation.api";
@@ -13,7 +13,7 @@ import { schemaApi } from "./apis/schema.api";
 import { contactList, deleteContact } from "./apis/contact.api";
 import { resolveOobi } from "./apis/oobi.api";
 
-const router = express.Router();
+const router: Router = express.Router();
 router.get(config.path.ping, ping);
 router.get(config.path.shorten, getFullUrl);
 router.post(config.path.createShorten, createShortenUrl);


### PR DESCRIPTION
## Description

Since we introduced the one-way scanning via the `/introduce` reply message, we have now lost the `createdAt` field of contacts in our server. keripy will auto add contacts if a resolved OOBI has an alias, but not a timestamp of creation time.

For now, I just want to stick in `createdAt` if we try to fetch a contact without a date as a temporary solution. I'd rather not add `createdAt` to keripy, at least not before aligning on its need. It's quite possible that the one-way scanning approach will change going forward to a request to connect setup, in which we can set the contact right away upon acceptance.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [[link](https://cardanofoundation.atlassian.net/browse/DTIS-2193)]