### PR TITLE
feat(ui): Allow optional and integer attributes to be set when issuing a credential

### DIFF
--- a/services/credential-server-ui/src/components/AppInput/AppInput.scss
+++ b/services/credential-server-ui/src/components/AppInput/AppInput.scss
@@ -3,4 +3,39 @@
     margin-left: 0.3rem;
     color: var(--color-neutral-500);
   }
+
+  .MuiInputBase-root,
+  .MuiOutlinedInput-root {
+    margin-top: 1.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--color-neutral-400);
+
+    input {
+      padding: 1rem 1.25rem;
+    }
+
+    &.Mui-focused {
+      border-color: var(--color-primary-700);
+    }
+
+    &.MuiInputBase-adornedStart {
+      padding-left: 1rem;
+
+      input {
+        padding: 1rem 0.5rem;
+      }
+    }
+  }
+
+  .MuiOutlinedInput-notchedOutline {
+    border: 0px;
+  }
+
+  .MuiInputBase-root.Mui-focused,
+  .MuiOutlinedInput-root.Mui-focused,
+  .MuiInputBase-root.Mui-error,
+  .MuiOutlinedInput-root.Mui-error {
+    border-width: 0.125rem;
+    border-style: solid;
+  }
 }

--- a/services/credential-server-ui/src/components/AppInput/AppInput.tsx
+++ b/services/credential-server-ui/src/components/AppInput/AppInput.tsx
@@ -13,7 +13,7 @@ interface AppInputProps extends InputBaseProps {
   label: string;
   optional?: boolean;
   errorMessage?: string;
-  type?: "string" | "number";
+  type?: "string" | "integer";
 }
 
 const AppInput = ({
@@ -57,7 +57,7 @@ const AppInput = ({
         <span className="app-input-optional">{i18n.t("general.optional")}</span>
       )}
     </InputLabel>
-    {type === "number" ? (
+    {type === "integer" ? (
       <NumberInput
         id={id}
         label={label}

--- a/services/credential-server-ui/src/components/AppInput/AppInput.tsx
+++ b/services/credential-server-ui/src/components/AppInput/AppInput.tsx
@@ -8,11 +8,13 @@ import {
 } from "@mui/material";
 import { i18n } from "../../i18n";
 import "./AppInput.scss";
+import { NumberInput } from "./NumberInput/NumberInput";
 
 interface AppInputProps extends InputBaseProps {
   label: string;
   optional?: boolean;
   errorMessage?: string;
+  type?: "string" | "number";
 }
 
 const CustomInput = styled(InputBase)(({ theme }) => ({
@@ -44,18 +46,31 @@ const CustomInput = styled(InputBase)(({ theme }) => ({
   },
 }));
 
-export const AppInput = ({
+const AppInput = ({
   label,
   optional,
   error,
   errorMessage,
   id,
   className,
+  type = "string",
+  onChange,
+  value,
+  min,
+  max,
+  step,
+  hideActionButtons,
   ...inputProps
-}: AppInputProps) => (
+}: AppInputProps & {
+  value?: number | string | null;
+  min?: number;
+  max?: number;
+  step?: number;
+  hideActionButtons?: boolean;
+}) => (
   <FormControl
     variant="standard"
-    className={`app-input ${className}`}
+    className={`app-input ${className ?? ""}`}
   >
     <InputLabel
       shrink
@@ -72,11 +87,37 @@ export const AppInput = ({
         <span className="app-input-optional">{i18n.t("general.optional")}</span>
       )}
     </InputLabel>
-    <CustomInput
-      {...inputProps}
-      id={id}
-      error={error}
-    />
+    {type === "number" ? (
+      <NumberInput
+        id={id}
+        error={error}
+        value={
+          typeof value === "number"
+            ? value
+            : value === ""
+              ? null
+              : Number(value)
+        }
+        onChange={onChange as ((value: number | null) => void) | undefined}
+        min={min}
+        max={max}
+        step={step}
+        hideActionButtons={hideActionButtons}
+      />
+    ) : (
+      <CustomInput
+        {...inputProps}
+        id={id}
+        error={error}
+        type="text"
+        value={
+          typeof value === "string" ? value : value == null ? "" : String(value)
+        }
+        onChange={onChange}
+      />
+    )}
     {error && <FormHelperText error>{errorMessage}</FormHelperText>}
   </FormControl>
 );
+
+export { AppInput };

--- a/services/credential-server-ui/src/components/AppInput/AppInput.tsx
+++ b/services/credential-server-ui/src/components/AppInput/AppInput.tsx
@@ -4,7 +4,6 @@ import {
   InputBase,
   InputBaseProps,
   InputLabel,
-  styled,
 } from "@mui/material";
 import { i18n } from "../../i18n";
 import "./AppInput.scss";
@@ -16,35 +15,6 @@ interface AppInputProps extends InputBaseProps {
   errorMessage?: string;
   type?: "string" | "number";
 }
-
-const CustomInput = styled(InputBase)(({ theme }) => ({
-  "label + &": {
-    marginTop: theme.spacing(3),
-  },
-  "&": {
-    borderRadius: "0.5rem",
-    border: "1px solid var(--color-neutral-400)",
-    "& input": {
-      padding: "1rem 1.25rem",
-    },
-    "&.Mui-focused": {
-      borderWidth: "2px",
-      borderStyle: "solid",
-      borderColor: theme.palette.primary.main,
-    },
-    "&.MuiInputBase-adornedStart": {
-      paddingLeft: "1rem",
-      input: {
-        padding: "1rem 0.5rem",
-      },
-    },
-  },
-  "&.Mui-error": {
-    borderWidth: "2px",
-    borderStyle: "solid",
-    borderColor: theme.palette.error.main,
-  },
-}));
 
 const AppInput = ({
   label,
@@ -90,7 +60,10 @@ const AppInput = ({
     {type === "number" ? (
       <NumberInput
         id={id}
+        label={label}
+        optional={optional}
         error={error}
+        errorMessage={errorMessage}
         value={
           typeof value === "number"
             ? value
@@ -105,7 +78,7 @@ const AppInput = ({
         hideActionButtons={hideActionButtons}
       />
     ) : (
-      <CustomInput
+      <InputBase
         {...inputProps}
         id={id}
         error={error}

--- a/services/credential-server-ui/src/components/AppInput/NumberInput/NumberInput.scss
+++ b/services/credential-server-ui/src/components/AppInput/NumberInput/NumberInput.scss
@@ -1,0 +1,32 @@
+.number-input {
+  .MuiInputBase-root {
+    padding-right: 0;
+
+    input {
+      text-align: center;
+    }
+  }
+
+  .MuiStack-root {
+    height: 3rem;
+    width: 1.5rem;
+    margin: 0.25rem;
+    border-radius: 0.25rem;
+    border: 1px solid var(--color-neutral-400);
+  }
+
+  .MuiButtonBase-root.number-input-btn {
+    border-radius: 0;
+    padding: 0.25rem 0rem;
+
+    &:first-of-type {
+      border-bottom: 1px solid var(--color-neutral-400);
+    }
+
+    svg {
+      height: 1rem;
+      width: 1rem;
+      fill: var(--color-neutral-700);
+    }
+  }
+}

--- a/services/credential-server-ui/src/components/AppInput/NumberInput/NumberInput.tsx
+++ b/services/credential-server-ui/src/components/AppInput/NumberInput/NumberInput.tsx
@@ -1,0 +1,146 @@
+import * as React from "react";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import {
+  IconButton,
+  InputAdornment,
+  Stack,
+  TextField,
+  type IconButtonProps,
+  type TextFieldProps,
+} from "@mui/material";
+import { i18n } from "../../../i18n";
+
+type NumberInputProps = Omit<TextFieldProps, "onChange" | "value"> & {
+  hideActionButtons?: boolean;
+  max?: number;
+  min?: number;
+  onChange?: (value: number | null) => void;
+  step?: number;
+  value?: number | null;
+};
+
+const NumberInput = React.forwardRef<HTMLDivElement, NumberInputProps>(
+  function NumberInput(props, ref) {
+    const {
+      disabled = false,
+      hideActionButtons = false,
+      max = Infinity,
+      min = -Infinity,
+      onChange,
+      size,
+      step = 1,
+      value: valueProp,
+      ...rest
+    } = props;
+
+    const isControlled = valueProp !== undefined && onChange !== undefined;
+    const [internalValue, setInternalValue] = React.useState<number | null>(
+      valueProp ?? null
+    );
+
+    React.useEffect(() => {
+      if (isControlled) setInternalValue(valueProp ?? null);
+    }, [valueProp, isControlled]);
+
+    const value = isControlled ? valueProp : internalValue;
+    const setValue = (val: number | null) => {
+      if (!isControlled) setInternalValue(val);
+      if (onChange) onChange(val);
+    };
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const val = e.target.value.replace(/[^\d-]/g, ""); // Only digits and minus
+      if (val === "" || val === "-") {
+        setValue(null);
+        return;
+      }
+      let num = Number(val);
+      if (!Number.isInteger(num)) return;
+      if (num > max) num = max;
+      if (num < min) num = min;
+      setValue(num);
+    };
+
+    const increment = () => {
+      const newValue =
+        (value != null && !Number.isNaN(value) ? value : 0) + step;
+      if (newValue > max) return;
+      setValue(newValue);
+    };
+
+    const decrement = () => {
+      const newValue =
+        (value != null && !Number.isNaN(value) ? value : 0) - step;
+      if (newValue < min) return;
+      setValue(newValue);
+    };
+
+    const handleBlur = () => {
+      if (value === null || value === undefined || !Number.isInteger(value)) {
+        setValue(min > -Infinity ? min : 0);
+      }
+    };
+
+    const commonAdornmentButtonProps: IconButtonProps = {
+      edge: "end",
+      sx: { p: size !== "small" ? "1px" : 0 },
+    };
+
+    return (
+      <TextField
+        {...rest}
+        ref={ref}
+        value={value ?? ""}
+        disabled={disabled}
+        size={size}
+        inputProps={{
+          inputMode: "numeric",
+          pattern: "[0-9]*",
+          min,
+          max,
+          step,
+        }}
+        onChange={handleInputChange}
+        onBlur={handleBlur}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowUp") {
+            event.preventDefault();
+            increment();
+          } else if (event.key === "ArrowDown") {
+            event.preventDefault();
+            decrement();
+          }
+        }}
+        slotProps={{
+          input: {
+            endAdornment: !hideActionButtons && (
+              <InputAdornment position="end">
+                <Stack>
+                  <IconButton
+                    aria-label={i18n.t("NumberInput.incrementAriaLabel")}
+                    disabled={disabled || (value ?? 0) + step > max}
+                    onClick={increment}
+                    {...commonAdornmentButtonProps}
+                  >
+                    <KeyboardArrowUpIcon fontSize={size} />
+                  </IconButton>
+                  <IconButton
+                    aria-label={i18n.t("NumberInput.decrementAriaLabel")}
+                    disabled={disabled || (value ?? 0) - step < min}
+                    onClick={decrement}
+                    {...commonAdornmentButtonProps}
+                  >
+                    <KeyboardArrowDownIcon fontSize={size} />
+                  </IconButton>
+                </Stack>
+              </InputAdornment>
+            ),
+          },
+        }}
+      />
+    );
+  }
+);
+
+export { NumberInput };

--- a/services/credential-server-ui/src/components/AppInput/NumberInput/NumberInput.tsx
+++ b/services/credential-server-ui/src/components/AppInput/NumberInput/NumberInput.tsx
@@ -2,14 +2,16 @@ import * as React from "react";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import {
-  IconButton,
+  FormControl,
   InputAdornment,
   Stack,
   TextField,
-  type IconButtonProps,
+  FormHelperText,
   type TextFieldProps,
 } from "@mui/material";
+import IconButton from "@mui/material/IconButton";
 import { i18n } from "../../../i18n";
+import "./NumberInput.scss";
 
 type NumberInputProps = Omit<TextFieldProps, "onChange" | "value"> & {
   hideActionButtons?: boolean;
@@ -18,6 +20,9 @@ type NumberInputProps = Omit<TextFieldProps, "onChange" | "value"> & {
   onChange?: (value: number | null) => void;
   step?: number;
   value?: number | null;
+  label: string;
+  optional?: boolean;
+  errorMessage?: string;
 };
 
 const NumberInput = React.forwardRef<HTMLDivElement, NumberInputProps>(
@@ -31,6 +36,12 @@ const NumberInput = React.forwardRef<HTMLDivElement, NumberInputProps>(
       size,
       step = 1,
       value: valueProp,
+      label,
+      optional,
+      error,
+      errorMessage,
+      id,
+      className,
       ...rest
     } = props;
 
@@ -50,7 +61,7 @@ const NumberInput = React.forwardRef<HTMLDivElement, NumberInputProps>(
     };
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const val = e.target.value.replace(/[^\d-]/g, ""); // Only digits and minus
+      const val = e.target.value.replace(/[^\d-]/g, "");
       if (val === "" || val === "-") {
         setValue(null);
         return;
@@ -77,68 +88,74 @@ const NumberInput = React.forwardRef<HTMLDivElement, NumberInputProps>(
     };
 
     const handleBlur = () => {
-      if (value === null || value === undefined || !Number.isInteger(value)) {
-        setValue(min > -Infinity ? min : 0);
-      }
-    };
-
-    const commonAdornmentButtonProps: IconButtonProps = {
-      edge: "end",
-      sx: { p: size !== "small" ? "1px" : 0 },
+      if (value === null || value === undefined) return;
+      const num = Number(value);
+      if (num > max) setValue(max);
+      else if (num < min) setValue(min);
     };
 
     return (
-      <TextField
-        {...rest}
-        ref={ref}
-        value={value ?? ""}
-        disabled={disabled}
-        size={size}
-        inputProps={{
-          inputMode: "numeric",
-          pattern: "[0-9]*",
-          min,
-          max,
-          step,
-        }}
-        onChange={handleInputChange}
-        onBlur={handleBlur}
-        onKeyDown={(event) => {
-          if (event.key === "ArrowUp") {
-            event.preventDefault();
-            increment();
-          } else if (event.key === "ArrowDown") {
-            event.preventDefault();
-            decrement();
-          }
-        }}
-        slotProps={{
-          input: {
-            endAdornment: !hideActionButtons && (
-              <InputAdornment position="end">
-                <Stack>
-                  <IconButton
-                    aria-label={i18n.t("NumberInput.incrementAriaLabel")}
-                    disabled={disabled || (value ?? 0) + step > max}
-                    onClick={increment}
-                    {...commonAdornmentButtonProps}
-                  >
-                    <KeyboardArrowUpIcon fontSize={size} />
-                  </IconButton>
-                  <IconButton
-                    aria-label={i18n.t("NumberInput.decrementAriaLabel")}
-                    disabled={disabled || (value ?? 0) - step < min}
-                    onClick={decrement}
-                    {...commonAdornmentButtonProps}
-                  >
-                    <KeyboardArrowDownIcon fontSize={size} />
-                  </IconButton>
-                </Stack>
-              </InputAdornment>
-            ),
-          },
-        }}
-      />
+      <FormControl
+        variant="standard"
+        className={`app-input number-input ${className ?? ""}`}
+        error={!!error}
+      >
+        <TextField
+          {...rest}
+          id={id}
+          inputRef={ref}
+          label={undefined}
+          value={value ?? ""}
+          disabled={disabled}
+          size={size}
+          error={!!error}
+          onChange={handleInputChange}
+          onBlur={handleBlur}
+          onKeyDown={(event) => {
+            if (event.key === "ArrowUp") {
+              event.preventDefault();
+              increment();
+            } else if (event.key === "ArrowDown") {
+              event.preventDefault();
+              decrement();
+            }
+          }}
+          slotProps={{
+            input: {
+              inputProps: {
+                inputMode: "numeric",
+                pattern: "[0-9]*",
+                min,
+                max,
+                step,
+              },
+              endAdornment: !hideActionButtons && (
+                <InputAdornment position="end">
+                  <Stack>
+                    <IconButton
+                      className="number-input-btn"
+                      aria-label={i18n.t("NumberInput.incrementAriaLabel")}
+                      disabled={disabled || (value ?? 0) + step > max}
+                      onClick={increment}
+                    >
+                      <KeyboardArrowUpIcon fontSize={size} />
+                    </IconButton>
+                    <IconButton
+                      className="number-input-btn"
+                      aria-label={i18n.t("NumberInput.decrementAriaLabel")}
+                      disabled={disabled || (value ?? 0) - step < min}
+                      onClick={decrement}
+                    >
+                      <KeyboardArrowDownIcon fontSize={size} />
+                    </IconButton>
+                  </Stack>
+                </InputAdornment>
+              ),
+            },
+          }}
+        />
+        {error && <FormHelperText error>{errorMessage}</FormHelperText>}
+      </FormControl>
     );
   }
 );

--- a/services/credential-server-ui/src/components/IssueCredentialModal/InputAttribute.tsx
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/InputAttribute.tsx
@@ -37,7 +37,8 @@ const InputAttribute = ({
             value={inputValue}
             onChange={
               type === "integer"
-                ? (val) => setValue(attribute, val == null ? "" : val)
+                ? // @ts-expect-error -- suppress type error for controlled number input
+                  (val) => setValue(attribute, val == null ? "" : val)
                 : (e) => setValue(attribute, e.target.value)
             }
             placeholder={i18n.t(

--- a/services/credential-server-ui/src/components/IssueCredentialModal/InputAttribute.tsx
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/InputAttribute.tsx
@@ -1,26 +1,78 @@
 import { Box } from "@mui/material";
+import { useEffect } from "react";
 import { i18n } from "../../i18n";
 import { AppInput } from "../AppInput";
 import { InputAttributeProps } from "./IssueCredentialModal.types";
+
+interface AttributeSchema {
+  type: string;
+  [key: string]: unknown;
+}
 
 const InputAttribute = ({
   attributes,
   value,
   setValue,
   required,
-}: InputAttributeProps) => {
+  properties,
+}: InputAttributeProps & { properties: Record<string, AttributeSchema> }) => {
+  useEffect(() => {
+    attributes.forEach((attribute) => {
+      const defaultValue = properties?.[attribute]?.default;
+      if (
+        (value[attribute] === undefined || value[attribute] === "") &&
+        (typeof defaultValue === "string" || typeof defaultValue === "number")
+      ) {
+        setValue(attribute, String(defaultValue));
+      }
+    });
+  }, [attributes, value, properties, setValue]);
+
   return (
     <Box className="input-attribute">
       {attributes.map((attribute) => {
         const inputLabelText = attribute.replace(/([a-z])([A-Z])/g, "$1 $2");
+        const schemaType = properties?.[attribute]?.type;
+        const type =
+          schemaType === "integer" || schemaType === "number"
+            ? "number"
+            : "string";
+
+        const defaultValue = properties?.[attribute]?.default;
+        let inputValue =
+          value[attribute] !== undefined && value[attribute] !== ""
+            ? value[attribute]
+            : typeof defaultValue === "string" ||
+                typeof defaultValue === "number" ||
+                defaultValue == null
+              ? defaultValue
+              : "";
+
+        if (type === "string") {
+          inputValue =
+            inputValue === undefined || inputValue === null
+              ? ""
+              : String(inputValue);
+        } else if (type === "number") {
+          inputValue =
+            inputValue === undefined || inputValue === null || inputValue === ""
+              ? null
+              : Number(inputValue);
+        }
 
         return (
           <AppInput
             key={attribute}
             fullWidth
-            label={`${inputLabelText.at(0)?.toUpperCase()}${inputLabelText.slice(1)} ${required ? "" : " (optional)"}`}
-            value={value[attribute] || ""}
-            onChange={(e) => setValue(attribute, e.target.value)}
+            label={`${inputLabelText.at(0)?.toUpperCase()}${inputLabelText.slice(1)}`}
+            type={type}
+            optional={!required}
+            value={inputValue}
+            onChange={
+              type === "number"
+                ? (val) => setValue(attribute, val == null ? "" : String(val))
+                : (e) => setValue(attribute, e.target.value)
+            }
             placeholder={i18n.t(
               "pages.credentialDetails.issueCredential.inputAttribute.placeholder"
             )}

--- a/services/credential-server-ui/src/components/IssueCredentialModal/InputAttribute.tsx
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/InputAttribute.tsx
@@ -20,10 +20,7 @@ const InputAttribute = ({
       {attributes.map((attribute) => {
         const inputLabelText = attribute.replace(/([a-z])([A-Z])/g, "$1 $2");
         const schemaType = properties?.[attribute]?.type;
-        const type =
-          schemaType === "integer" || schemaType === "number"
-            ? "number"
-            : "string";
+        const type = schemaType === "integer" ? "integer" : "string";
 
         const inputValue: string =
           value[attribute] !== undefined && value[attribute] !== null
@@ -39,8 +36,8 @@ const InputAttribute = ({
             optional={!required}
             value={inputValue}
             onChange={
-              type === "number"
-                ? (val) => setValue(attribute, val == null ? "" : String(val))
+              type === "integer"
+                ? (val) => setValue(attribute, val == null ? "" : val)
                 : (e) => setValue(attribute, e.target.value)
             }
             placeholder={i18n.t(

--- a/services/credential-server-ui/src/components/IssueCredentialModal/InputAttribute.tsx
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/InputAttribute.tsx
@@ -7,6 +7,7 @@ const InputAttribute = ({
   attributes,
   value,
   setValue,
+  required,
 }: InputAttributeProps) => {
   return (
     <Box className="input-attribute">
@@ -17,7 +18,7 @@ const InputAttribute = ({
           <AppInput
             key={attribute}
             fullWidth
-            label={`${inputLabelText.at(0)?.toUpperCase()}${inputLabelText.slice(1)}`}
+            label={`${inputLabelText.at(0)?.toUpperCase()}${inputLabelText.slice(1)} ${required ? "" : " (optional)"}`}
             value={value[attribute] || ""}
             onChange={(e) => setValue(attribute, e.target.value)}
             placeholder={i18n.t(

--- a/services/credential-server-ui/src/components/IssueCredentialModal/InputAttribute.tsx
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/InputAttribute.tsx
@@ -1,5 +1,4 @@
 import { Box } from "@mui/material";
-import { useEffect } from "react";
 import { i18n } from "../../i18n";
 import { AppInput } from "../AppInput";
 import { InputAttributeProps } from "./IssueCredentialModal.types";
@@ -16,18 +15,6 @@ const InputAttribute = ({
   required,
   properties,
 }: InputAttributeProps & { properties: Record<string, AttributeSchema> }) => {
-  useEffect(() => {
-    attributes.forEach((attribute) => {
-      const defaultValue = properties?.[attribute]?.default;
-      if (
-        (value[attribute] === undefined || value[attribute] === "") &&
-        (typeof defaultValue === "string" || typeof defaultValue === "number")
-      ) {
-        setValue(attribute, String(defaultValue));
-      }
-    });
-  }, [attributes, value, properties, setValue]);
-
   return (
     <Box className="input-attribute">
       {attributes.map((attribute) => {
@@ -38,27 +25,10 @@ const InputAttribute = ({
             ? "number"
             : "string";
 
-        const defaultValue = properties?.[attribute]?.default;
-        let inputValue =
-          value[attribute] !== undefined && value[attribute] !== ""
-            ? value[attribute]
-            : typeof defaultValue === "string" ||
-                typeof defaultValue === "number" ||
-                defaultValue == null
-              ? defaultValue
-              : "";
-
-        if (type === "string") {
-          inputValue =
-            inputValue === undefined || inputValue === null
-              ? ""
-              : String(inputValue);
-        } else if (type === "number") {
-          inputValue =
-            inputValue === undefined || inputValue === null || inputValue === ""
-              ? null
-              : Number(inputValue);
-        }
+        const inputValue: string =
+          value[attribute] !== undefined && value[attribute] !== null
+            ? String(value[attribute])
+            : "";
 
         return (
           <AppInput

--- a/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.scss
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.scss
@@ -1,9 +1,15 @@
 .issue-cred-modal {
-  .popup-modal-container .popup-modal-footer .footer {
-    width: 100%;
-    display: flex;
-    gap: 0.75rem;
-    margin-top: 1.5rem;
+  .popup-modal-container {
+    > *:not(:last-child) {
+      margin-bottom: 1.5rem;
+    }
+
+    .popup-modal-footer .footer {
+      width: 100%;
+      display: flex;
+      gap: 0.75rem;
+      margin-bottom: 0;
+    }
   }
 
   &.stage-0,

--- a/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.scss
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.scss
@@ -65,6 +65,10 @@
     .content {
       color: var(--color-neutral-800);
     }
+
+    > *:not(:last-child) {
+      margin-bottom: 1.5rem;
+    }
   }
 
   .input-attribute {

--- a/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.tsx
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.tsx
@@ -20,14 +20,13 @@ import { IssueCredListTemplate } from "./IssueCredListTemplate";
 import { Review } from "./Review";
 import { IGNORE_ATTRIBUTES } from "../../const";
 
-const RESET_TIMEOUT = 1000;
-
 const IssueCredentialModal = ({
   open,
   onClose,
   credentialTypeId,
   connectionId,
 }: IssueCredentialModalProps) => {
+  const RESET_TIMEOUT = 1000;
   const connections = useAppSelector((state) => state.connections.contacts);
   const schemas = useAppSelector((state) => state.schemasCache.schemas);
   const dispatch = useAppDispatch();
@@ -38,8 +37,23 @@ const IssueCredentialModal = ({
   const [selectedCredTemplate, setSelectedCredTemplate] =
     useState(credentialTypeId);
   const [attributes, setAttributes] = useState<Record<string, string>>({});
-
   const [loading, setLoading] = useState(false);
+  const schema = schemas.find((item) => item.$id === selectedCredTemplate);
+  const properties = schema?.properties?.a?.oneOf?.[1]?.properties || {};
+  const requiredList = schema?.properties?.a?.oneOf?.[1]?.required || [];
+  const attributeKeys = Object.keys(properties).filter(
+    (key) => !IGNORE_ATTRIBUTES.includes(key)
+  );
+  const renderedRequiredList = requiredList.filter((key) =>
+    attributeKeys.includes(key)
+  );
+  const allRequiredAttributesFilled =
+    currentStage !== IssueCredentialStage.InputAttribute
+      ? true
+      : renderedRequiredList.every(
+          (key) =>
+            attributes[key] !== undefined && attributes[key].trim() !== ""
+        );
 
   const credTemplateName = selectedCredTemplate
     ? schemas.find((item) => item.$id === selectedCredTemplate)?.title
@@ -96,15 +110,15 @@ const IssueCredentialModal = ({
       (currentStage === IssueCredentialStage.SelectConnection &&
         !selectedConnection) ||
       (currentStage === IssueCredentialStage.InputAttribute &&
-        Object.values(attributes).every((item) => !item)) ||
+        !allRequiredAttributesFilled) ||
       loading
     );
   }, [
     currentStage,
     selectedCredTemplate,
     selectedConnection,
-    attributes,
     loading,
+    allRequiredAttributesFilled,
   ]);
 
   const issueCred = async () => {
@@ -163,6 +177,9 @@ const IssueCredentialModal = ({
             className="neutral-button"
             startIcon={<ArrowBackOutlinedIcon />}
             onClick={() => {
+              if (currentStage !== IssueCredentialStage.Review) {
+                setAttributes({});
+              }
               setCurrentStage(
                 getBackStage(currentStage, !credentialTypeId) ||
                   IssueCredentialStage.SelectConnection
@@ -231,28 +248,16 @@ const IssueCredentialModal = ({
         );
       }
       case IssueCredentialStage.InputAttribute: {
-        const schema = schemas.find(
-          (item) => item.$id === selectedCredTemplate
-        );
-        const properties = schema?.properties.a.oneOf[1].properties || {};
-        const requiredList = schema?.properties.a.oneOf[1].required || [];
-        const attributeKeys = Object.keys(properties).filter(
-          (key) => !IGNORE_ATTRIBUTES.includes(key)
-        );
-
-        return (
-          <>
-            {attributeKeys.map((attribute) => (
-              <InputAttribute
-                key={attribute}
-                value={attributes}
-                setValue={updateAttributes}
-                attributes={[attribute]}
-                required={requiredList.includes(attribute)}
-              />
-            ))}
-          </>
-        );
+        return attributeKeys.map((attribute) => (
+          <InputAttribute
+            key={attribute}
+            value={attributes}
+            setValue={updateAttributes}
+            attributes={[attribute]}
+            required={requiredList.includes(attribute)}
+            properties={properties}
+          />
+        ));
       }
       case IssueCredentialStage.Review:
         return (

--- a/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.tsx
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.tsx
@@ -128,11 +128,14 @@ const IssueCredentialModal = ({
 
     const schemaSaid = selectedCredTemplate;
     let objAttributes = {};
-    const attribute: Record<string, string> = {};
-
-    Object.entries(attributes).forEach(([key, value]) => {
-      if (key && value) attribute[key] = value;
-    });
+    const attribute = Object.fromEntries(
+      Object.entries(attributes).filter(
+        ([_, v]) =>
+          v !== undefined &&
+          v !== null &&
+          !(typeof v === "string" && v.trim() === "")
+      )
+    );
 
     if (Object.keys(attribute).length) {
       objAttributes = {

--- a/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.tsx
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.tsx
@@ -234,19 +234,24 @@ const IssueCredentialModal = ({
         const schema = schemas.find(
           (item) => item.$id === selectedCredTemplate
         );
-        const schemaRequiredAttributes =
-          schema?.properties.a.oneOf[1].required || [];
-
-        const requiredAttributes = schemaRequiredAttributes.filter(
-          (item) => !IGNORE_ATTRIBUTES.includes(item)
+        const properties = schema?.properties.a.oneOf[1].properties || {};
+        const requiredList = schema?.properties.a.oneOf[1].required || [];
+        const attributeKeys = Object.keys(properties).filter(
+          (key) => !IGNORE_ATTRIBUTES.includes(key)
         );
 
         return (
-          <InputAttribute
-            value={attributes}
-            setValue={updateAttributes}
-            attributes={requiredAttributes}
-          />
+          <>
+            {attributeKeys.map((attribute) => (
+              <InputAttribute
+                key={attribute}
+                value={attributes}
+                setValue={updateAttributes}
+                attributes={[attribute]}
+                required={requiredList.includes(attribute)}
+              />
+            ))}
+          </>
         );
       }
       case IssueCredentialStage.Review:

--- a/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.tsx
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.tsx
@@ -259,15 +259,21 @@ const IssueCredentialModal = ({
           />
         ));
       }
-      case IssueCredentialStage.Review:
+      case IssueCredentialStage.Review: {
+        const nonEmptyAttributes = Object.fromEntries(
+          Object.entries(attributes).filter(
+            ([_, v]) => v !== undefined && v !== null && String(v).trim() !== ""
+          )
+        );
         return (
           <Review
             credentialType={credTemplateName}
-            attribute={attributes}
+            attribute={nonEmptyAttributes}
             connectionId={selectedConnection}
             connections={connections}
           />
         );
+      }
       default:
         return null;
     }

--- a/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.types.ts
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/IssueCredentialModal.types.ts
@@ -11,6 +11,7 @@ interface InputAttributeProps {
   attributes: string[];
   value: Record<string, string>;
   setValue: (key: string, value: string) => void;
+  required: boolean;
 }
 
 interface IssueCredListData {

--- a/services/credential-server-ui/src/components/IssueCredentialModal/Review.tsx
+++ b/services/credential-server-ui/src/components/IssueCredentialModal/Review.tsx
@@ -25,7 +25,7 @@ const Review = ({
 
   return (
     <Box className="review-stage">
-      <Box sx={{ textAlign: "left", marginBottom: "1.5rem" }}>
+      <Box sx={{ textAlign: "left" }}>
         <Typography variant="subtitle1">
           {i18n.t("pages.credentialDetails.issueCredential.review.credential")}
         </Typography>
@@ -34,7 +34,6 @@ const Review = ({
             display: "flex",
             alignItems: "center",
             gap: 1,
-            marginBottom: "1.5rem",
           }}
         >
           <img
@@ -50,7 +49,7 @@ const Review = ({
           </Typography>
         </Box>
       </Box>
-      <Box sx={{ textAlign: "left", marginBottom: "1.5rem" }}>
+      <Box sx={{ textAlign: "left" }}>
         <Typography variant="subtitle1">
           {i18n.t("pages.credentialDetails.issueCredential.review.issueTo")}
         </Typography>


### PR DESCRIPTION
## Description

As described in the linked ticket below, we are:

- Looping through all the attributes as defined in the schema (instead of only showing one).
- Introducing a new type (integer, on top of the existing string type)

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [**DTIS-2251**](https://cardanofoundation.atlassian.net/issues/DTIS-2251)

https://github.com/user-attachments/assets/f58d7d78-703d-4a1b-a720-09b9beebbf8a


