### PR TITLE
fix(cred-server): ensure signifyReady is called before starting the server

### DIFF
--- a/services/credential-server/src/server.ts
+++ b/services/credential-server/src/server.ts
@@ -15,8 +15,6 @@ async function getSignifyClient(
   bran: string,
   aidName: string
 ): Promise<SignifyApi> {
-  await signifyReady();
-
   const signifyApi = new SignifyApi();
   await signifyApi.start(bran);
 
@@ -73,6 +71,7 @@ async function startServer() {
   });
 
   app.listen(config.port, async () => {
+    await signifyReady();
     const brans = await loadBrans();
     const signifyApi = await getSignifyClient(brans.bran, ISSUER_NAME);
     const signifyApiIssuer = await getSignifyClient(brans.issuerBran, QVI_NAME);


### PR DESCRIPTION
## Description

Fixes a startup bug in the Credential Issuance Server where it attempts to use Signify before it’s fully ready, causing initialization to fail. This update ensures the server waits for Signify to be ready before proceeding, allowing proper startup and expected behavior.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [DTIS-2290 - Credential Server - Signify Not Ready on Startup](https://cardanofoundation.atlassian.net/browse/DTIS-2290)

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [X] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [X] No secrets are being committed (i.e. credentials, PII)
- [X] This PR does not have any significant security implications

### Code Review

- [X] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [X] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated