### PR TITLE
fix(ui): Set passcode screen pushes numeric keyboard

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,7 @@ export default {
   ],
   coverageDirectory: "coverage",
   coverageProvider: "v8",
-  coverageReporters: ["clover", "json", "lcov", "text", "text-summary"],
+  coverageReporters: ["clover", "json", "lcov"],
   coverageThreshold: {
     global: {
       statements: 80,
@@ -47,5 +47,5 @@ export default {
     "\\.yaml$": "jest-transform-yaml",
   },
   setupFilesAfterEnv: ["jest-canvas-mock", "<rootDir>/src/setupTests.ts"],
-  setupFiles: ["<rootDir>/src/ui/__mocks__/swiper.tsx"]
+  setupFiles: ["<rootDir>/src/ui/__mocks__/swiper.tsx"],
 };

--- a/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.scss
+++ b/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.scss
@@ -40,19 +40,7 @@
     margin: 0;
   }
 
-  .forgot-your-passcode-placeholder {
-    height: 4.625rem;
-  }
-
-  @media screen and (min-height: 300px) and (max-height: 600px) {
-    .forgot-your-passcode-placeholder {
-      height: 2rem;
-    }
-  }
-
-  @media screen and (min-height: 300px) and (max-height: 600px) {
-    .forgot-your-passcode-placeholder {
-      height: 4.5rem;
-    }
+  .hide {
+    visibility: hidden;
   }
 }

--- a/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.test.tsx
+++ b/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.test.tsx
@@ -122,7 +122,7 @@ describe("SetPasscode Page", () => {
 
   test("Renders Create Passcode page with title and description", () => {
     require("@ionic/react");
-    const { getByText } = render(
+    const { getByText, getByTestId } = render(
       <Provider store={store}>
         <CreatePasscodeModule
           title={EN_TRANSLATIONS.setpasscode.enterpasscode}
@@ -138,6 +138,7 @@ describe("SetPasscode Page", () => {
     expect(
       getByText(EN_TRANSLATIONS.setpasscode.description)
     ).toBeInTheDocument();
+    expect(getByTestId("set-passcode-footer")).toHaveClass("hide");
   });
 
   test("The user can add and remove digits from the passcode", () => {
@@ -240,7 +241,7 @@ describe("SetPasscode Page", () => {
     );
   });
 
-  test("Display an consecutive passcode", async () => {
+  test("Display a consecutive passcode", async () => {
     verifySecretMock.mockResolvedValue(true);
     isReverseConsecutiveMock.mockImplementation(() => true);
     const { getByText, queryByText, getByTestId } = render(

--- a/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.tsx
+++ b/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.tsx
@@ -277,14 +277,10 @@ const CreatePasscodeModule = forwardRef<
         />
         <PageFooter
           pageId={testId}
-          customClass={originalPassCode == "" ? "hide" : ""}
+          customClass={originalPassCode === "" ? "hide " : ""}
           secondaryButtonText={`${i18n.t("createpasscodemodule.cantremember")}`}
           secondaryButtonAction={() => handleClearState()}
-        >
-          {originalPassCode == "" && (
-            <span data-testid="forgot-your-passcode-placeholder" />
-          )}
-        </PageFooter>
+        />
         <Alert
           isOpen={showSetupBiometricsAlert}
           setIsOpen={setShowSetupBiometricsAlert}

--- a/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.tsx
+++ b/src/ui/components/CreatePasscodeModule/CreatePasscodeModule.tsx
@@ -275,20 +275,16 @@ const CreatePasscodeModule = forwardRef<
           handlePinChange={handlePinChange}
           handleRemove={handleRemove}
         />
-        {originalPassCode !== "" ? (
-          <PageFooter
-            pageId={testId}
-            secondaryButtonText={`${i18n.t(
-              "createpasscodemodule.cantremember"
-            )}`}
-            secondaryButtonAction={() => handleClearState()}
-          />
-        ) : (
-          <div
-            className="forgot-your-passcode-placeholder"
-            data-testid="forgot-your-passcode-placeholder"
-          />
-        )}
+        <PageFooter
+          pageId={testId}
+          customClass={originalPassCode == "" ? "hide" : ""}
+          secondaryButtonText={`${i18n.t("createpasscodemodule.cantremember")}`}
+          secondaryButtonAction={() => handleClearState()}
+        >
+          {originalPassCode == "" && (
+            <span data-testid="forgot-your-passcode-placeholder" />
+          )}
+        </PageFooter>
         <Alert
           isOpen={showSetupBiometricsAlert}
           setIsOpen={setShowSetupBiometricsAlert}

--- a/src/ui/pages/Menu/components/Settings/components/ChangePin/ChangePin.test.tsx
+++ b/src/ui/pages/Menu/components/Settings/components/ChangePin/ChangePin.test.tsx
@@ -109,7 +109,7 @@ describe("ChangePin Modal", () => {
       )
     ).toBeInTheDocument();
     expect(getByTestId("passcode-module-container")).toBeInTheDocument();
-    expect(getByTestId("forgot-your-passcode-placeholder")).toBeInTheDocument();
+    expect(getByTestId("change-pin-footer")).toHaveClass("hide");
   });
 
   test("Renders Re-enter Passcode when first time passcode is set", async () => {
@@ -143,8 +143,9 @@ describe("ChangePin Modal", () => {
     await waitFor(() =>
       expect(
         queryByText(EN_TRANSLATIONS.createpasscodemodule.cantremember)
-      ).toBeInTheDocument()
+      ).toBeVisible()
     );
+    expect(getByTestId("change-pin-footer")).not.toHaveClass("hide");
   });
 
   test("Set passcode and close modal when second passcode is entered correctly", async () => {


### PR DESCRIPTION
## Description

Fixing a bug where the passcode module seems jumping between entering and verifying due to a wrong placeholder. 

Removing the placeholder and using the same component but with a hidden class so it won't be visible but will keep the same size.

## Checklist before requesting a review

### Issue ticket number and link

- [ ] This PR has a valid ticket number or issue: [**DTIS-2299**](https://cardanofoundation.atlassian.net/issues/DTIS-2299)

### Testing & Validation

- [ ] This PR has been tested/validated in IOS, Android and browser.
- [ ] The code has been tested locally with test coverage match expectations.
- [ ] Added new Unit/Component testing (if relevant).

### Security

- [ ] No secrets are being committed (i.e. credentials, PII)
- [ ] This PR does not have any significant security implications

### Code Review

- [ ] There is no unused functionality or blocks of commented out code (otherwise, please explain below)
- [ ] In addition to this PR, all relevant documentation (e.g. Confluence) and architecture diagrams (e.g. Miro) were updated

### Design Review

- [ ] If this PR contains changes to the UI, it has gone through a design review with UX Designer or Product owner.
- [ ] In case PR contains changes to the UI, add some screenshots to notice the differences
---
#### IOS
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Android
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)

#### Browser
##### _Before_

[comment]: <> (Add screenshots)

##### _After_

[comment]: <> (Add screenshots)