### PR TITLE
feat(ui): No default profile after recovery

### DIFF
--- a/src/store/reducers/stateCache/stateCache.ts
+++ b/src/store/reducers/stateCache/stateCache.ts
@@ -190,6 +190,9 @@ const stateCacheSlice = createSlice({
     setIsSetupProfile: (state, action: PayloadAction<boolean | undefined>) => {
       state.isSetupProfile = action.payload;
     },
+    setDefaultProfile: (state, action: PayloadAction<string>) => {
+      state.authentication.defaultProfile = action.payload;
+    },
   },
 });
 
@@ -219,6 +222,7 @@ const {
   clearStateCache,
   showGlobalLoading,
   setIsSetupProfile,
+  setDefaultProfile,
 } = stateCacheSlice.actions;
 
 const getStateCache = (state: RootState) => state.stateCache;
@@ -305,4 +309,5 @@ export {
   showGlobalLoading,
   showNoWitnessAlert,
   stateCacheSlice,
+  setDefaultProfile,
 };

--- a/src/ui/pages/CreateSSIAgent/CreateSSIAgent.test.tsx
+++ b/src/ui/pages/CreateSSIAgent/CreateSSIAgent.test.tsx
@@ -51,7 +51,10 @@ import {
   setCurrentOperation,
   setIsOnline,
 } from "../../../store/reducers/stateCache";
-import { filteredIdentifierMapFix } from "../../__fixtures__/filteredIdentifierFix";
+import {
+  filteredIdentifierFix,
+  filteredIdentifierMapFix,
+} from "../../__fixtures__/filteredIdentifierFix";
 import { CustomInputProps } from "../../components/CustomInput/CustomInput.types";
 import {
   ONBOARDING_DOCUMENTATION_LINK,
@@ -942,6 +945,16 @@ describe("SSI agent page: recovery mode", () => {
 
     act(() => {
       store.dispatch(setIsOnline(true));
+    });
+
+    jest.spyOn(global.Date, "now").mockImplementationOnce(() => 1);
+    await waitFor(() => {
+      expect(createOrUpdateBasicRecordMock).toBeCalledWith(
+        expect.objectContaining({
+          id: MiscRecordId.DEFAULT_PROFILE,
+          content: { defaultProfile: filteredIdentifierFix[0].id },
+        })
+      );
     });
 
     await waitFor(() => {


### PR DESCRIPTION
<!--
* Please:
   ✓ Set a good, conventional commit style PR title.
   ✓ Write a good description that explains what this PR is meant to do.
   ✓ Keep PRs small, and manageable for reviewers.
   ✓ Set as draft until ready, and self-reviewed.
   ✓ Keep screenshots small using <img src="URL_HERE" width="35%">.
   ✓ Make sure you have all green ticks on GitHub actions before asking for a review.
-->

## Description

Fix issue about missing default profile after recovery wallet.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [VT20-1981](https://cardanofoundation.atlassian.net/browse/VT20-1981)

### Testing & Validation

- [x] This PR has been tested/validated in iOS, Android and browser.
- [x] Added new unit tests, if relevant.

### Design Review

- [x] In case this PR contains changes to the UI, add some screenshots and/or videos to show the changes on relevant devices.

### Browser

https://github.com/user-attachments/assets/5b678a02-c8af-4452-b28f-bcfa64d025a4



[VT20-1981]: https://cardanofoundation.atlassian.net/browse/VT20-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ