### PR TITLE
chore: enable external prs to build docker images

### DIFF
--- a/.github/workflows/docker-builds.yaml
+++ b/.github/workflows/docker-builds.yaml
@@ -62,7 +62,7 @@ jobs:
           platforms: arm64
 
       - name: ⛮ cf-gha-baseline
-        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-baseline@main
+        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-baseline@feat/add-external-pr-check-for-gha-baseline
         id: cf-gha-baseline
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -115,13 +115,7 @@ jobs:
           if [ ${{github.event_name}} == "pull_request" ]
           then
 
-            # Fetch PR metadata
-            PR_HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
-            PR_HEAD_REF="${{ github.event.pull_request.head.ref }}"
-            PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-            PR_BASE_REPO="${{ github.repository }}"
-            
-            if [ "$PR_HEAD_REPO" != "$PR_BASE_REPO" ]; then
+            if [ "$IS_PR_FROM_FORK" == "true" ]; then
               echo "External PR detected: fetching branch from $PR_HEAD_REPO"
               git fetch https://github.com/${PR_HEAD_REPO}.git "$PR_HEAD_REF"
               git checkout FETCH_HEAD

--- a/.github/workflows/docker-builds.yaml
+++ b/.github/workflows/docker-builds.yaml
@@ -1,5 +1,13 @@
 name: Build and publish docker artifacts
 
+###############################################################################
+# WARNING:
+# This workflow uses pull_request_target to allow building images from forks,
+# this means that secrets are exposed and we should never run anything code
+# outside a sandbox (ie, docker containers) to prevent potential malicious code
+# leaking the github actions secrets.
+###############################################################################
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/docker-builds.yaml
+++ b/.github/workflows/docker-builds.yaml
@@ -12,6 +12,13 @@ on:
     - '.github/workflows/docker-builds.yaml'
     - 'services/credential-server-ui/**'
     - 'services/credential-server/**'
+  pull_request_target:
+    types: [ opened, synchronize ]
+    paths:
+    - 'Earthfile'
+    - '.github/workflows/docker-builds.yaml'
+    - 'services/credential-server-ui/**'
+    - 'services/credential-server/**'
   workflow_dispatch:
     inputs:
       images:
@@ -112,7 +119,7 @@ jobs:
             echo "DOCKER_IMAGES_TARGETS_$(echo ${{ matrix.platform }} | sed 's|/|_|g')=${DOCKER_IMAGES_TARGETS}" | tee -a "$GITHUB_ENV" | tee -a "$GITHUB_OUTPUT"
           fi
           
-          if [ ${{github.event_name}} == "pull_request" ]
+          if [ "$TRIGGERING_REF" == "pr" ]
           then
 
             if [ "$IS_PR_FROM_FORK" == "true" ]; then
@@ -166,7 +173,7 @@ jobs:
         run: |
           set -x
           # For PR builds, we skip any earthly build if there are no changes on any known target-related file, for branch builds, we just build everything
-          if [ ${{github.event_name}} == "pull_request" ]
+          if [ "$TRIGGERING_REF" == "pr" ]
           then
             if [ ! -z "${DOCKER_IMAGES_TARGETS}" ]
             then
@@ -272,7 +279,7 @@ jobs:
               --DOCKER_REGISTRIES="${DOCKER_REGISTRIES_FILTERED}" \
               --DOCKER_IMAGES_EXTRA_TAGS="${EARTHLY_DOCKER_IMAGES_EXTRA_TAGS}"
           else
-              if [ "${{github.event_name}}" == "pull_request" ]
+              if [ "$TRIGGERING_REF" == "pr" ]
               then
                 echo "[+] No changes on any known target-related file, skipping earthly build..."
                 exit 0

--- a/.github/workflows/docker-builds.yaml
+++ b/.github/workflows/docker-builds.yaml
@@ -114,7 +114,21 @@ jobs:
           
           if [ ${{github.event_name}} == "pull_request" ]
           then
-            git checkout ${BRANCH_NAME}
+
+						# Fetch PR metadata
+						PR_HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+						PR_HEAD_REF="${{ github.event.pull_request.head.ref }}"
+						PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+						PR_BASE_REPO="${{ github.repository }}"
+						
+						if [ "$PR_HEAD_REPO" != "$PR_BASE_REPO" ]; then
+						  echo "External PR detected: fetching branch from $PR_HEAD_REPO"
+						  git fetch https://github.com/${PR_HEAD_REPO}.git "$PR_HEAD_REF"
+						  git checkout FETCH_HEAD
+						else
+						  echo "Internal PR: checking out branch $PR_HEAD_REF"
+            	git checkout ${BRANCH_NAME}
+						fi
 
             # set earthly docker image targets based on changed paths
             set +e

--- a/.github/workflows/docker-builds.yaml
+++ b/.github/workflows/docker-builds.yaml
@@ -115,20 +115,20 @@ jobs:
           if [ ${{github.event_name}} == "pull_request" ]
           then
 
-						# Fetch PR metadata
-						PR_HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
-						PR_HEAD_REF="${{ github.event.pull_request.head.ref }}"
-						PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-						PR_BASE_REPO="${{ github.repository }}"
-						
-						if [ "$PR_HEAD_REPO" != "$PR_BASE_REPO" ]; then
-						  echo "External PR detected: fetching branch from $PR_HEAD_REPO"
-						  git fetch https://github.com/${PR_HEAD_REPO}.git "$PR_HEAD_REF"
-						  git checkout FETCH_HEAD
-						else
-						  echo "Internal PR: checking out branch $PR_HEAD_REF"
+            # Fetch PR metadata
+            PR_HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+            PR_HEAD_REF="${{ github.event.pull_request.head.ref }}"
+            PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            PR_BASE_REPO="${{ github.repository }}"
+            
+            if [ "$PR_HEAD_REPO" != "$PR_BASE_REPO" ]; then
+              echo "External PR detected: fetching branch from $PR_HEAD_REPO"
+              git fetch https://github.com/${PR_HEAD_REPO}.git "$PR_HEAD_REF"
+              git checkout FETCH_HEAD
+            else
+              echo "Internal PR: checking out branch $PR_HEAD_REF"
             	git checkout ${BRANCH_NAME}
-						fi
+            fi
 
             # set earthly docker image targets based on changed paths
             set +e

--- a/.github/workflows/docker-builds.yaml
+++ b/.github/workflows/docker-builds.yaml
@@ -62,7 +62,7 @@ jobs:
           platforms: arm64
 
       - name: ⛮ cf-gha-baseline
-        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-baseline@feat/add-external-pr-check-for-gha-baseline
+        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-baseline@main
         id: cf-gha-baseline
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-builds.yaml
+++ b/.github/workflows/docker-builds.yaml
@@ -5,13 +5,6 @@ on:
     branches: [ main ]
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
-    types: [ opened, synchronize ]
-    paths:
-    - 'Earthfile'
-    - '.github/workflows/docker-builds.yaml'
-    - 'services/credential-server-ui/**'
-    - 'services/credential-server/**'
   pull_request_target:
     types: [ opened, synchronize ]
     paths:


### PR DESCRIPTION
This PR switches to our `docker-builds` pipeline to be trigger on `pull_request_target` events in order to have the secrets exposed for external PRs also so we can push docker images for these PRs to our private docker registry.
This usually comes at the risk of leaking secrets as the pipeline will execute code from external forks, but given that in this pipeline everything is sandboxed into docker containers, secrets are never exposed.

It's important to remember this consideration in case in the future we decide to run some tests (or whatever) directly from the github action within this pipeline, that's why I'm adding a banner into the workflow file as a reminder 😅 