### PR TITLE
test(jest): Fix failing unit test in SEDI branch

### DIFF
--- a/src/ui/pages/NotificationDetails/NotificationDetails.test.tsx
+++ b/src/ui/pages/NotificationDetails/NotificationDetails.test.tsx
@@ -34,6 +34,14 @@ jest.mock("../../../core/agent/agent", () => ({
         getIpexApplyDetails: jest.fn(() => Promise.resolve(credRequestFix)),
         getAcdcFromIpexGrant: jest.fn(() => Promise.resolve(credsFixAcdc[0])),
         getLinkedGroupFromIpexApply: jest.fn(),
+        getLinkedGroupFromIpexGrant: jest.fn(() =>
+          Promise.resolve({
+            threshold: { main: 2, total: 3 },
+            members: ["member1", "member2", "member3"],
+            othersJoined: ["member1"],
+            linkedRequest: {},
+          })
+        ),
       },
     },
   },
@@ -161,8 +169,8 @@ describe("Notification Detail", () => {
     };
 
     const history = createMemoryHistory();
-    const path = `${TabsRoutePath.NOTIFICATIONS}/${notificationsFix[6].id}`;
-    history.push(path, notificationsFix[6]);
+    const path = `${TabsRoutePath.NOTIFICATIONS}/${notificationsFix[0].id}`;
+    history.push(path, notificationsFix[0]);
 
     const { getByTestId } = render(
       <IonReactMemoryRouter


### PR DESCRIPTION
<!--
* Please:
   ✓ Set a good, conventional commit style PR title.
   ✓ Write a good description that explains what this PR is meant to do.
   ✓ Keep PRs small, and manageable for reviewers.
   ✓ Set as draft until ready, and self-reviewed.
   ✓ Keep screenshots small using <img src="URL_HERE" width="35%">.
   ✓ Make sure you have all green ticks on GitHub actions before asking for a review.
-->

## Description

The test now passes. The issue was that the test was using notificationsFix[5] (which has route "/multisig/exn" for multisig receive), but the test setup didn't have the proper mocks for multisig operations, causing the component to not render.

## Checklist before requesting a review

### Issue ticket number and link

- [x] This PR has a valid ticket number or issue: [**VT20-2170**](https://cardanofoundation.atlassian.net/browse/VT20-2170)

### Testing & Validation

- [ ] This PR has been tested/validated in iOS, Android and browser.
- [x] Added new unit tests, if relevant.

### Design Review

- [ ] In case this PR contains changes to the UI, add some screenshots and/or videos to show the changes on relevant devices.

