### PR TITLE
chore(gha): pin every github action version to specific commits

### DIFF
--- a/.github/workflows/build-and-publish-docker-artifacts.yaml
+++ b/.github/workflows/build-and-publish-docker-artifacts.yaml
@@ -61,18 +61,18 @@ jobs:
       matrix: ${{fromJson(needs.set-matrix.outputs.matrix)}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Setup qemu for arm builds
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         if: matrix.platform == 'linux/arm64'
         with:
           platforms: arm64
 
       - name: ⛮ cf-gha-baseline
-        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-baseline@main
+        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-baseline@234ee2fbd4073e759aba6f3ca53e912ab8403886 # main at 02/10/2025
         id: cf-gha-baseline
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -231,7 +231,7 @@ jobs:
             fi
           fi
 
-      - uses: cloudposse/github-action-matrix-outputs-write@v1
+      - uses: cloudposse/github-action-matrix-outputs-write@ed06cf3a6bf23b8dce36d1cf0d63123885bb8375 # v1.0.0
         id: out
         with:
           matrix-step-name: ${{ github.job }}
@@ -249,7 +249,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
 
       # Manually doing this instead of using the cloudposse/read action as it seems there is some issue with it
       - name: read-matrix-artifacts
@@ -261,12 +261,12 @@ jobs:
           echo DOCKER_IMAGES_TARGETS=${DOCKER_IMAGES_TARGETS} | tee -a "$GITHUB_ENV" | tee -a "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: ⛮ cf-gha-baseline
-        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-baseline@main
+        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-baseline@234ee2fbd4073e759aba6f3ca53e912ab8403886 # main at 02/10/2025
         id: cf-gha-baseline
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -314,16 +314,16 @@ jobs:
       - merge-multi-platform-manifests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: ⛮ cf-gha-baseline
-        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-baseline@main
+        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-baseline@234ee2fbd4073e759aba6f3ca53e912ab8403886 # main at 02/10/2025
         id: cf-gha-baseline
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Dispatch successful build event to private repo
-        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-dispatch-event@main
+        uses: cardano-foundation/cf-gha-workflows/./actions/cf-gha-dispatch-event@234ee2fbd4073e759aba6f3ca53e912ab8403886 # main at 02/10/2025
         with:
           EVENT_TYPE: "${{ github.event_name }}-${{ steps.cf-gha-baseline.outputs.TRIGGERING_REF }}-${{ steps.cf-gha-baseline.outputs.BRANCH_NAME }}"
           GITHUB_TOKEN: ${{ secrets.PRIVATE_REPO_PAT }}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
           submodules: recursive
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: "package.json"
 

--- a/.github/workflows/dependency-check-google-osv.yaml
+++ b/.github/workflows/dependency-check-google-osv.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         submodules: recursive
 
@@ -34,7 +34,7 @@ jobs:
         echo 'services/*' >> .gitignore
 
     - name: Upload .gitignore artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: gitignore-artifact
         include-hidden-files: true

--- a/.github/workflows/dependency-check-npm-audit.yaml
+++ b/.github/workflows/dependency-check-npm-audit.yaml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
           submodules: recursive
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: "package.json"
 
@@ -51,6 +51,6 @@ jobs:
 
     - name: Upload SARIF file to GitHub Security tab
       if: always()
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
       with:
         sarif_file: audit.sarif.json

--- a/.github/workflows/dependency-check-owasp-android.yml
+++ b/.github/workflows/dependency-check-owasp-android.yml
@@ -27,13 +27,13 @@ jobs:
       NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           submodules: recursive
 
       # Run OWASP Dependency-Check via the official Action
       - name: Run Dependency-Check
-        uses: dependency-check/Dependency-Check_Action@main
+        uses: dependency-check/Dependency-Check_Action@2ba636726705b0f74f126ebeaacaf2ad4600b967 # main at 01/10/2025
         with:
           project: "veridian-wallet-android"
           path: "android"
@@ -43,12 +43,12 @@ jobs:
         continue-on-error: false
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: depcheck-android-report
           path: "reports/dependency-check-report.html"
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
         with:
           sarif_file: "reports/dependency-check-report.sarif"

--- a/.github/workflows/dependency-check-owasp-ios.yml
+++ b/.github/workflows/dependency-check-owasp-ios.yml
@@ -27,13 +27,13 @@ jobs:
       NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           submodules: recursive
 
       # Run OWASP Dependency-Check via the official Action
       - name: Run Dependency-Check
-        uses: dependency-check/Dependency-Check_Action@main
+        uses: dependency-check/Dependency-Check_Action@2ba636726705b0f74f126ebeaacaf2ad4600b967 # main at 01/10/2025
         with:
           project: "veridian-wallet-ios"
           path: "ios"
@@ -43,12 +43,12 @@ jobs:
         continue-on-error: false
 
       - name: Upload HTML report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: depcheck-ios-report
           path: "reports/dependency-check-report.html"
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
         with:
           sarif_file: "reports/dependency-check-report.sarif"

--- a/.github/workflows/e2e-mobile-tests.yaml
+++ b/.github/workflows/e2e-mobile-tests.yaml
@@ -7,14 +7,14 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: 🦾 Create .env file
         run: |
           echo APP_PATH=$HOME/Documents/xcode/DerivedData/Build/Products/Debug-iphonesimulator/App.app > .env
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 18
 


### PR DESCRIPTION
Trying to remove some warnings from [zizmor reports](https://github.com/cardano-foundation/veridian-wallet/security/code-scanning?page=1&query=is%3Aopen+branch%3Amain+tool%3Azizmor) :)
