### PR TITLE
fix(core): set contact details if connecting to previously one-way scanned contact

### DIFF
--- a/src/core/agent/services/keriaNotificationService.test.ts
+++ b/src/core/agent/services/keriaNotificationService.test.ts
@@ -3383,65 +3383,7 @@ describe("Long running operation tracker", () => {
       oobi: "oobi",
       id: "id",
       createdAt: new Date(),
-    });
-
-    await keriaNotificationService.processOperation(operationRecord);
-
-    expect(connectionPairStorage.update).toHaveBeenCalledWith({
-      contactId: "id",
-      creationStatus: CreationStatus.COMPLETE,
-      identifier: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_p9",
-      pendingDeletion: false,
-    });
-    expect(contactsUpdateMock).toBeCalledTimes(0);
-    expect(eventEmitter.emit).toHaveBeenCalledWith({
-      type: EventTypes.OperationComplete,
-      payload: {
-        opType: operationRecord.recordType,
-        oid: "AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
-      },
-    });
-    expect(operationPendingStorage.deleteById).toBeCalledWith(
-      "oobi.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA"
-    );
-  });
-
-  test("Should not update connection if it already exists", async () => {
-    Agent.agent.getKeriaOnlineStatus = jest.fn().mockReturnValue(true);
-    const operationMock = {
-      metadata: {
-        said: "said",
-        oobi: "http://keria:3902/oobi/ELDjcyhsjppizfKQ_AvYeF4RuF1u0O6ya6OYUM6zLYH-/agent/EI4-oLA5XcrZepuB5mDrl3279EjbFtiDrz4im5Q4Ht0O?name=CF%20Credential%20Issuance",
-      },
-      done: true,
-      response: {
-        i: "id",
-        dt: new Date(),
-      },
-    };
-    operationsGetMock.mockResolvedValue(operationMock);
-    operationsGetMock.mockResolvedValue(operationMock);
-    const connectionPairMock = {
-      contactId: "id",
-      creationStatus: CreationStatus.PENDING,
-      identifier: "EGrdtLIlSIQHF1gHhE7UVfs9yRF-EDhqtLT41pJlj_p9",
-      pendingDeletion: false,
-    };
-    connectionPairStorage.findAllByQuery.mockResolvedValueOnce([
-      connectionPairMock,
-    ]);
-    const operationRecord = {
-      type: "OperationPendingRecord",
-      id: "oobi.AOCUvGbpidkplC7gAoJOxLgXX1P2j4xlWMbzk3gM8JzA",
-      createdAt: new Date("2024-08-01T10:36:17.814Z"),
-      recordType: "oobi",
-      updatedAt: new Date("2024-08-01T10:36:17.814Z"),
-    } as OperationPendingRecord;
-    contactGetMock.mockResolvedValueOnce({
-      alias: "alias",
-      oobi: "oobi",
-      id: "id",
-      createdAt: new Date(),
+      version: "versionHere",
     });
 
     await keriaNotificationService.processOperation(operationRecord);

--- a/src/core/agent/services/keriaNotificationService.ts
+++ b/src/core/agent/services/keriaNotificationService.ts
@@ -950,7 +950,6 @@ class KeriaNotificationService extends AgentService {
     notif: Notification,
     exchange: ExnMessage
   ): Promise<boolean> {
-
     // TODO: different requirement?
     if (exchange.exn.a.s) {
       return true;
@@ -964,7 +963,6 @@ class KeriaNotificationService extends AgentService {
     notif: Notification,
     exchange: ExnMessage
   ): Promise<boolean> {
-
     if (exchange.exn.a.s) {
       return true;
     }
@@ -1306,7 +1304,7 @@ class KeriaNotificationService extends AgentService {
               .get((operation.response as State).i)
               .catch(() => undefined);
 
-            if (!keriaContact) {
+            if (!keriaContact || !keriaContact.version) {
               const contact = await this.contactStorage.findById(
                 connectionPairRecord.contactId
               );


### PR DESCRIPTION
<!--
* Please:
   ✓ Set a good, conventional commit style PR title.
   ✓ Write a good description that explains what this PR is meant to do.
   ✓ Keep PRs small, and manageable for reviewers.
   ✓ Set as draft until ready, and self-reviewed.
   ✓ Keep screenshots small using <img src="URL_HERE" width="35%">.
   ✓ Make sure you have all green ticks on GitHub actions before asking for a review.
-->

## Description

One-way scanning (`/introduce` rpy msg) causes contact creation if the name query param is passed. Our core skips contact creation if it already exists so we don't overwrite the creation date for repeated OOBI resolutions, but this conflicts with one-way scanning. It also conflicts with our new profile based UX, so a further fix is needed on main for the recovery flow, but this will do here for now.

## Checklist before requesting a review

### Issue ticket number and link

- [X] This PR has a valid ticket number or issue: [**VT20-2109**](https://cardanofoundation.atlassian.net/browse/VT20-2109)

### Testing & Validation

- [X] This PR has been tested/validated in iOS, Android and browser.
- [ ] Added new unit tests, if relevant.

### Design Review

- [ ] In case this PR contains changes to the UI, add some screenshots and/or videos to show the changes on relevant devices.

